### PR TITLE
[FEAT] Entity Class 매핑하기 - #8

### DIFF
--- a/cubco-domain/build.gradle
+++ b/cubco-domain/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     runtimeOnly 'com.mysql:mysql-connector-j'
 

--- a/cubco-domain/src/main/java/org/cubco/cafe/domain/Cafe.java
+++ b/cubco-domain/src/main/java/org/cubco/cafe/domain/Cafe.java
@@ -1,0 +1,38 @@
+package org.cubco.cafe.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.cubco.common.BaseTimeEntity;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED) @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+@Table(name = "cafes")
+public class Cafe extends BaseTimeEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "cafe_id")
+    private Long id;
+
+    @Column(name = "name")
+    private String name;
+
+    @Column(name = "address")
+    private String address;
+
+    @Column(name = "hours")
+    private String hours;
+
+    @Column(name = "thumbnail_url")
+    private String thumbnail;
+
+    public static Cafe create(String name, String address, String hours, String thumbnail) {
+        return Cafe.builder()
+                .name(name)
+                .address(address)
+                .hours(hours)
+                .thumbnail(thumbnail)
+                .build();
+    }
+}

--- a/cubco-domain/src/main/java/org/cubco/cafecuration/domain/CafeCuration.java
+++ b/cubco-domain/src/main/java/org/cubco/cafecuration/domain/CafeCuration.java
@@ -1,0 +1,40 @@
+package org.cubco.cafecuration.domain;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+import org.cubco.cafe.domain.Cafe;
+import org.cubco.common.BaseTimeEntity;
+import org.cubco.curation.domain.Curation;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED) @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+@Table(name = "cafe_curations")
+public class CafeCuration extends BaseTimeEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "cafe_curation_id")
+    private Long id;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "cafe_id")
+    private Cafe cafe;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "curation_id")
+    private Curation curation;
+
+    /**
+     * Ex) 강남 뷰 맛집 카페 추천 TOP5 와 같이 큐레이션 내에 여러 카페가 들어갈 경우 호출
+     */
+    public static CafeCuration create(Cafe cafe, Curation curation) {
+        return CafeCuration.builder()
+                .cafe(cafe)
+                .curation(curation)
+                .build();
+    }
+}

--- a/cubco-domain/src/main/java/org/cubco/common/BaseTimeEntity.java
+++ b/cubco-domain/src/main/java/org/cubco/common/BaseTimeEntity.java
@@ -1,0 +1,35 @@
+package org.cubco.common;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+/**
+ * 공통적으로 사용되는 생성일/수정일 필드를 포함한 엔티티 상속 클래스
+ */
+@Getter
+@MappedSuperclass
+@SuperBuilder
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED) @AllArgsConstructor(access = AccessLevel.PRIVATE)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate // Entity가 생성되어 저장될 때 시간이 자동 저장
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate // 조회한 Entity의 값을 변경할 때 시간이 자동 저장
+    @Column(name = "modified_at")
+    private LocalDateTime modifiedAt;
+
+}

--- a/cubco-domain/src/main/java/org/cubco/config/JpaConfig.java
+++ b/cubco-domain/src/main/java/org/cubco/config/JpaConfig.java
@@ -1,0 +1,9 @@
+package org.cubco.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@EnableJpaAuditing
+@Configuration
+public class JpaConfig {
+}

--- a/cubco-domain/src/main/java/org/cubco/coupon/domain/Coupon.java
+++ b/cubco-domain/src/main/java/org/cubco/coupon/domain/Coupon.java
@@ -1,0 +1,45 @@
+package org.cubco.coupon.domain;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+import org.cubco.cafe.domain.Cafe;
+import org.cubco.common.BaseTimeEntity;
+import org.cubco.user.domain.User;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED) @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@Table(name = "coupons")
+public class Coupon extends BaseTimeEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "coupon_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "cafe_id")
+    private Cafe cafe;
+
+    @Builder.Default
+    @NotNull
+    @Column(name = "count")
+    private int count = 0;
+
+    @Column(name = "image_url")
+    private String imageUrl;
+
+    public static Coupon create(User user, Cafe cafe, int count, String imageUrl) {
+        return Coupon.builder()
+                .user(user)
+                .cafe(cafe)
+                .count(count)
+                .imageUrl(imageUrl)
+                .build();
+    }
+}

--- a/cubco-domain/src/main/java/org/cubco/curation/domain/Curation.java
+++ b/cubco-domain/src/main/java/org/cubco/curation/domain/Curation.java
@@ -1,0 +1,39 @@
+package org.cubco.curation.domain;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+import org.cubco.common.BaseTimeEntity;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED) @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+@Table(name = "curations")
+public class Curation extends BaseTimeEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "curation_id")
+    private Long id;
+
+    @NotNull
+    @Column(name = "title")
+    private String title;
+
+    @NotNull
+    @Column(name = "content")
+    private String content;
+
+    @Builder.Default
+    @NotNull
+    @Column(name = "report_count")
+    private int reportCount = 0;
+
+    public static Curation create(String title, String content, int reportCount) {
+        return Curation.builder()
+                .title(title)
+                .content(content)
+                .reportCount(reportCount)
+                .build();
+    }
+}

--- a/cubco-domain/src/main/java/org/cubco/image/domain/CurationImage.java
+++ b/cubco-domain/src/main/java/org/cubco/image/domain/CurationImage.java
@@ -1,0 +1,40 @@
+package org.cubco.image.domain;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+import org.cubco.common.BaseTimeEntity;
+import org.cubco.curation.domain.Curation;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED) @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+@Table(name = "curation_images")
+public class CurationImage extends BaseTimeEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "image_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "curation_id")
+    @NotNull
+    private Curation curation;
+
+    @NotNull
+    @Column(name = "image_url")
+    private String imageUrl;
+
+    @NotNull
+    @Column(name = "sort_order")
+    private int sortOrder;
+
+    public static CurationImage create(Curation curation, String imageUrl, int sortOrder) {
+        return CurationImage.builder()
+                .curation(curation)
+                .imageUrl(imageUrl)
+                .sortOrder(sortOrder)
+                .build();
+    }
+}

--- a/cubco-domain/src/main/java/org/cubco/image/domain/ReviewImage.java
+++ b/cubco-domain/src/main/java/org/cubco/image/domain/ReviewImage.java
@@ -1,0 +1,40 @@
+package org.cubco.image.domain;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+import org.cubco.common.BaseTimeEntity;
+import org.cubco.review.domain.Review;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED) @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+@Table(name = "review_images")
+public class ReviewImage extends BaseTimeEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "image_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "review_id")
+    @NotNull
+    private Review review;
+
+    @NotNull
+    @Column(name = "image_url")
+    private String imageUrl;
+
+    @NotNull
+    @Column(name = "sort_order")
+    private int sortOrder;
+
+    public static ReviewImage create(Review review, String imageUrl, int sortOrder) {
+        return ReviewImage.builder()
+                .review(review)
+                .imageUrl(imageUrl)
+                .sortOrder(sortOrder)
+                .build();
+    }
+}

--- a/cubco-domain/src/main/java/org/cubco/like/domain/Like.java
+++ b/cubco-domain/src/main/java/org/cubco/like/domain/Like.java
@@ -1,0 +1,38 @@
+package org.cubco.like.domain;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+import org.cubco.common.BaseTimeEntity;
+import org.cubco.curation.domain.Curation;
+import org.cubco.user.domain.User;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED) @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+@Table(name = "likes")
+public class Like extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "like_id")
+    private Long id;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "curation_id")
+    private Curation curation;
+
+    public static Like create(User user, Curation curation) {
+        return Like.builder()
+                .user(user)
+                .curation(curation)
+                .build();
+    }
+}

--- a/cubco-domain/src/main/java/org/cubco/report/domain/CurationReport.java
+++ b/cubco-domain/src/main/java/org/cubco/report/domain/CurationReport.java
@@ -1,0 +1,29 @@
+package org.cubco.report.domain;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+import org.cubco.curation.domain.Curation;
+import org.cubco.user.domain.User;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SuperBuilder
+@Table(name = "curation_reports")
+public class CurationReport extends Report {
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "curation_id")
+    private Curation curation;
+
+    public static CurationReport create(User reporter, Curation curation, ReportReason reason) {
+        return CurationReport.builder()
+                .reporter(reporter)
+                .curation(curation)
+                .reason(reason)
+                .build();
+    }
+}

--- a/cubco-domain/src/main/java/org/cubco/report/domain/Report.java
+++ b/cubco-domain/src/main/java/org/cubco/report/domain/Report.java
@@ -1,0 +1,30 @@
+package org.cubco.report.domain;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+import org.cubco.common.BaseTimeEntity;
+import org.cubco.user.domain.User;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED) @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@SuperBuilder
+@Getter
+@MappedSuperclass
+public abstract class Report extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "report_id")
+    private Long id;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User reporter;
+
+    @Enumerated(EnumType.STRING)
+    @NotNull
+    @Column(name = "reason")
+    private ReportReason reason;
+}

--- a/cubco-domain/src/main/java/org/cubco/report/domain/ReportReason.java
+++ b/cubco-domain/src/main/java/org/cubco/report/domain/ReportReason.java
@@ -1,0 +1,20 @@
+package org.cubco.report.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum ReportReason {
+
+    FISHING_HARASSMENT_SPAM("스팸"),
+    LEAKING_FRAUD("정보유출"),
+    PORNOGRAPHY("성적인 내용"),
+    INAPPROPRIATE_CONTENT("부적절한 컨텐츠"),
+    INSULT("모욕"),
+    COMMERCIAL_AD("광고"),
+    POLITICAL_CONTENT("정치적 발언");
+
+    private final String value;
+}

--- a/cubco-domain/src/main/java/org/cubco/report/domain/ReviewReport.java
+++ b/cubco-domain/src/main/java/org/cubco/report/domain/ReviewReport.java
@@ -1,0 +1,29 @@
+package org.cubco.report.domain;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+import org.cubco.review.domain.Review;
+import org.cubco.user.domain.User;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SuperBuilder
+@Table(name = "review_reports")
+public class ReviewReport extends Report {
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "review_id")
+    private Review review;
+
+    public static ReviewReport create(User reporter, Review review, ReportReason reason) {
+        return ReviewReport.builder()
+                .reporter(reporter)
+                .review(review)
+                .reason(reason)
+                .build();
+    }
+}

--- a/cubco-domain/src/main/java/org/cubco/review/domain/Review.java
+++ b/cubco-domain/src/main/java/org/cubco/review/domain/Review.java
@@ -1,0 +1,53 @@
+package org.cubco.review.domain;
+
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+import org.cubco.cafe.domain.Cafe;
+import org.cubco.common.BaseTimeEntity;
+import org.cubco.user.domain.User;
+
+import java.math.BigDecimal;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED) @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+@Table(name = "reviews")
+public class Review extends BaseTimeEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "review_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "cafe_id")
+    private Cafe cafe;
+
+    @NotNull
+    @Column(name = "content")
+    private String content;
+
+    @NotNull
+    @Column(name = "rating", precision = 3, scale = 2)
+    private BigDecimal rating;
+
+    @Builder.Default
+    @NotNull
+    @Column(name = "report_count")
+    private int reportCount = 0;
+
+    public static Review create(User user, Cafe cafe, String content, BigDecimal rating) {
+        return Review.builder()
+                .user(user)
+                .cafe(cafe)
+                .content(content)
+                .rating(rating)
+                .build();
+    }
+}

--- a/cubco-domain/src/main/java/org/cubco/scrap/domain/Scrap.java
+++ b/cubco-domain/src/main/java/org/cubco/scrap/domain/Scrap.java
@@ -1,0 +1,34 @@
+package org.cubco.scrap.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.cubco.cafe.domain.Cafe;
+import org.cubco.common.BaseTimeEntity;
+import org.cubco.user.domain.User;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED) @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+@Table(name = "scraps")
+public class Scrap extends BaseTimeEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "scrap_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "cafe_id")
+    private Cafe cafe;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    public static Scrap create(Cafe cafe, User user) {
+        return Scrap.builder()
+                .cafe(cafe)
+                .user(user)
+                .build();
+    }
+}

--- a/cubco-domain/src/main/java/org/cubco/stamphistory/domain/StampHistory.java
+++ b/cubco-domain/src/main/java/org/cubco/stamphistory/domain/StampHistory.java
@@ -1,0 +1,51 @@
+package org.cubco.stamphistory.domain;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+import org.cubco.cafe.domain.Cafe;
+import org.cubco.common.BaseTimeEntity;
+import org.cubco.user.domain.User;
+
+import java.time.LocalDateTime;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED) @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+@Table(name = "stamp_histories")
+public class StampHistory extends BaseTimeEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "stamp_history_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @NotNull
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @NotNull
+    @JoinColumn(name = "cafe_id")
+    private Cafe cafe;
+
+    @Enumerated(EnumType.STRING)
+    @NotNull
+    @Column(name = "status")
+    private StampStatus status;
+
+    @Column(name = "approved_at")
+    private LocalDateTime approvedAt; // 승인 시간. 승인될 경우에만 ( 승인 안 되면 modifiedAt 으로 대체 가능 )
+
+    /**
+     * 스탬프 내역은 적립 요청 시 최초 생성 되기에 approvedAt은 null, 나중에 승인 될 경우 update 비즈니스 로직 추가
+     */
+    public static StampHistory create(User user, Cafe cafe, StampStatus status) {
+        return StampHistory.builder()
+                .user(user)
+                .cafe(cafe)
+                .status(status)
+                .build();
+    }
+}

--- a/cubco-domain/src/main/java/org/cubco/stamphistory/domain/StampStatus.java
+++ b/cubco-domain/src/main/java/org/cubco/stamphistory/domain/StampStatus.java
@@ -1,0 +1,13 @@
+package org.cubco.stamphistory.domain;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum StampStatus {
+    ACCEPTED("승인"),
+    REJECTED("거부"),
+    PENDING("보류");
+
+    private final String value;
+}

--- a/cubco-domain/src/main/java/org/cubco/tag/domain/CafeTag.java
+++ b/cubco-domain/src/main/java/org/cubco/tag/domain/CafeTag.java
@@ -1,0 +1,33 @@
+package org.cubco.tag.domain;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+import org.cubco.cafe.domain.Cafe;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED) @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+@Table(name = "cafe_tags")
+public class CafeTag {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "cafe_tag_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "cafe_id")
+    private Cafe cafe;
+
+    @NotNull
+    @Column(name = "name")
+    private String name;
+
+    public static CafeTag create(Cafe cafe, String name) {
+        return CafeTag.builder()
+                .cafe(cafe)
+                .name(name)
+                .build();
+    }
+}

--- a/cubco-domain/src/main/java/org/cubco/tag/domain/CurationTag.java
+++ b/cubco-domain/src/main/java/org/cubco/tag/domain/CurationTag.java
@@ -1,0 +1,33 @@
+package org.cubco.tag.domain;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+import org.cubco.curation.domain.Curation;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED) @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+@Table(name = "curation_tags")
+public class CurationTag {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "curation_tag_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "curation_id")
+    private Curation curation;
+
+    @NotNull
+    @Column(name = "name")
+    private String name;
+
+    public static CurationTag create(Curation curation, String name) {
+        return CurationTag.builder()
+                .curation(curation)
+                .name(name)
+                .build();
+    }
+}

--- a/cubco-domain/src/main/java/org/cubco/user/domain/RoleType.java
+++ b/cubco-domain/src/main/java/org/cubco/user/domain/RoleType.java
@@ -1,0 +1,14 @@
+package org.cubco.user.domain;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum RoleType {
+
+    MEMBER("member"),
+    ADMIN("admin"),
+    MANAGER("manager");
+
+    private final String value;
+}

--- a/cubco-domain/src/main/java/org/cubco/user/domain/SocialType.java
+++ b/cubco-domain/src/main/java/org/cubco/user/domain/SocialType.java
@@ -1,0 +1,14 @@
+package org.cubco.user.domain;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum SocialType {
+
+    TEST("test"),
+    GOOGLE("google"),
+    APPLE("apple");
+
+    private final String value;
+}

--- a/cubco-domain/src/main/java/org/cubco/user/domain/Status.java
+++ b/cubco-domain/src/main/java/org/cubco/user/domain/Status.java
@@ -1,0 +1,14 @@
+package org.cubco.user.domain;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum Status {
+
+    ACTIVE("active"),
+    INACTIVE("inactive"),
+    DELETED("deleted");
+
+    private final String value;
+}

--- a/cubco-domain/src/main/java/org/cubco/user/domain/User.java
+++ b/cubco-domain/src/main/java/org/cubco/user/domain/User.java
@@ -1,0 +1,71 @@
+package org.cubco.user.domain;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+import org.cubco.common.BaseTimeEntity;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED) @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+@Table(name = "users")
+public class User extends BaseTimeEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long id;
+
+    @NotNull
+    @Column(name = "name")
+    private String name;
+
+    @NotNull
+    @Column(name = "email")
+    private String email;
+
+    @NotNull
+    @Column(name = "phone")
+    private String phone;
+
+    @NotNull
+    @Column(name = "city")
+    private String city;
+
+    @Builder.Default
+    @NotNull
+    @Column(name = "report_count")
+    private int reportCount = 0;
+
+    @NotNull
+    @Column(name = "social_id")
+    private String socialId;
+
+    @Enumerated(EnumType.STRING)
+    @NotNull
+    @Column(name = "role_type")
+    private RoleType roleType;
+
+    @Enumerated(EnumType.STRING)
+    @NotNull
+    @Column(name = "social_type")
+    private SocialType socialType;
+
+    @Enumerated(EnumType.STRING)
+    @NotNull
+    @Column(name = "status")
+    private Status status;
+
+    public static User create(String name, String email, String phone, String city, SocialType socialType, String socialId) {
+        return User.builder()
+                .name(name)
+                .email(email)
+                .phone(phone)
+                .city(city)
+                .socialType(socialType)
+                .socialId(socialId)
+                .status(Status.ACTIVE)
+                .roleType(RoleType.MEMBER)
+                .build();
+    }
+}


### PR DESCRIPTION
## 🔥*Pull requests*

#️⃣️ **작업한 브랜치**
- feature/#8

📄  **작업한 내용**
![cubco-diagram](https://github.com/user-attachments/assets/b14743cf-3464-455e-a704-cfcdb6d11c0d)
- ERD 입니다.
- NoArgsConstructor 어노테이션의 접근 레벨을  protected로 설정함으로써 무분별한 엔티티 객체 생성을 제한 및 JPA 지연로딩 시 프록시 객체가 상속 가능하도록 하였습니다.
- 정적 팩토리 메서드를 통해 엔티티 생성을 제한하고 관리하기 위해 AllArgsConstructor 어노테이션과 Builder의 접근 레벨을 private로 설정하였습니다.
- 중복 필드를 가진 Entity들의 경우 SuperBuilder 어노테이션을 추가하여 부모 필드까지 빌더 패턴을 통해 자식클래스에서 활용 가능하도록 했습니다.
#
## Entity
- 신고 Entity 구현
  - 중복 필드 부분을 Report 추상클래스로 구현
    - https://github.com/GDSC-Daejin/project-cubco-backend/blob/253e1f4a133993a4e580dbbb38d891bd657c86b2/cubco-domain/src/main/java/org/cubco/report/domain/Report.java#L10-L30
  - 자식 클래스 ( CurationReport.java, ReviewReport.java )
    - https://github.com/GDSC-Daejin/project-cubco-backend/blob/253e1f4a133993a4e580dbbb38d891bd657c86b2/cubco-domain/src/main/java/org/cubco/report/domain/ReviewReport.java#L10-L29
    - https://github.com/GDSC-Daejin/project-cubco-backend/blob/253e1f4a133993a4e580dbbb38d891bd657c86b2/cubco-domain/src/main/java/org/cubco/report/domain/CurationReport.java#L10-L29
    - SuperBuilder 어노테이션을 통해 부모 클래스의 필드명을 활용할 수 있습니다.
- 유저 Entity 구현
- 카페 Entity 구현
  - 카페 Tag와 큐레이션 Tag를 분리하여 구현하였습니다.
- 쿠폰 Entity 구현
- 스크랩 Entity 구현
- 쿠폰 Entity 구현
- 이미지 Entity 구현
  - CurationImage와 ReviewImage로 분리하여 구현하였습니다.
- 좋아요 Entity 구현
- 리뷰 Entity 구현
- 스탬프 Entity 구현
- 큐레이션 Entity 구현

## 🚨 참고 사항
- 원래 정적 팩토리 메서드는 네이밍은 of로 하는건데 Entity 내부에선 DTO 와 겹치지 않게 create로 설정하였습니다.
- 추후에 DTO에 정적 팩토리 메서드 구현 시 of 로 하시면 됩니다.

## 💻 관련 이슈
- Resolved: #8 