### PR TITLE
[chore] 공통 응답 객체 구조 변경 - #20

### DIFF
--- a/cubco-api/src/main/java/org/cubco/controller/TestController.java
+++ b/cubco-api/src/main/java/org/cubco/controller/TestController.java
@@ -7,6 +7,7 @@
 //import org.cubco.exception.CustomException;
 //import org.cubco.exception.ErrorCode;
 //import org.cubco.swagger.TestApiDocs;
+//import org.springframework.http.HttpStatus;
 //import org.springframework.web.bind.annotation.GetMapping;
 //import org.springframework.web.bind.annotation.RequestMapping;
 //import org.springframework.web.bind.annotation.RestController;
@@ -17,7 +18,7 @@
 //
 //    @GetMapping("/success")
 //    public CommonResponse<?> createUser() {
-//        return CommonResponse.createSuccessWithNoContent("성공");
+//        return CommonResponse.createSuccess(HttpStatus.OK ,"성공", "data");
 //    }
 //
 //    @GetMapping("/error")

--- a/cubco-api/src/main/java/org/cubco/exception/GlobalExceptionHandler.java
+++ b/cubco-api/src/main/java/org/cubco/exception/GlobalExceptionHandler.java
@@ -28,7 +28,7 @@ public class GlobalExceptionHandler {
         ErrorCode errorCode = ex.getErrorCode();
         return ResponseEntity
                 .status(errorCode.getHttpStatus())
-                .body(CommonResponse.createError(errorCode.getCode(), errorCode.getMessage()));
+                .body(CommonResponse.createError(errorCode.getHttpStatus(), errorCode.getCode(), errorCode.getMessage()));
     }
 
     // [2] 예상치 못한 서버 내부 예외 처리
@@ -38,7 +38,7 @@ public class GlobalExceptionHandler {
         ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
         return ResponseEntity
                 .status(errorCode.getHttpStatus())
-                .body(CommonResponse.createError(errorCode.getCode(), errorCode.getMessage()));
+                .body(CommonResponse.createError(errorCode.getHttpStatus(), errorCode.getCode(), errorCode.getMessage()));
     }
 
     // [3] DTO 유효성 검사 실패 (ex: @Valid)
@@ -58,7 +58,7 @@ public class GlobalExceptionHandler {
         ErrorCode errorCode = ErrorCode.METHOD_NOT_ALLOWED;
         return ResponseEntity
                 .status(errorCode.getHttpStatus())
-                .body(CommonResponse.createError(errorCode.getCode(), errorCode.getMessage()));
+                .body(CommonResponse.createError(errorCode.getHttpStatus(), errorCode.getCode(), errorCode.getMessage()));
     }
 
     // [5] JSON 파싱 오류 (ex: 잘못된 형식의 JSON Body)
@@ -68,7 +68,7 @@ public class GlobalExceptionHandler {
         ErrorCode errorCode = ErrorCode.INVALID_REQUEST;
         return ResponseEntity
                 .status(errorCode.getHttpStatus())
-                .body(CommonResponse.createError(errorCode.getCode(), errorCode.getMessage()));
+                .body(CommonResponse.createError(errorCode.getHttpStatus(), errorCode.getCode(), errorCode.getMessage()));
     }
 
     // [6] 필수 쿼리 파라미터 누락
@@ -78,7 +78,7 @@ public class GlobalExceptionHandler {
         ErrorCode errorCode = ErrorCode.MISSING_REQUIRED_FIELD;
         return ResponseEntity
                 .status(errorCode.getHttpStatus())
-                .body(CommonResponse.createError(errorCode.getCode(), errorCode.getMessage()));
+                .body(CommonResponse.createError(errorCode.getHttpStatus(), errorCode.getCode(), errorCode.getMessage()));
     }
 
     // [7] 단일 필드 유효성 검증 실패 (ex: @RequestParam 검증)
@@ -88,7 +88,7 @@ public class GlobalExceptionHandler {
         ErrorCode errorCode = ErrorCode.INVALID_INPUT_VALUE;
         return ResponseEntity
                 .status(errorCode.getHttpStatus())
-                .body(CommonResponse.createError(errorCode.getCode(), errorCode.getMessage()));
+                .body(CommonResponse.createError(errorCode.getHttpStatus(), errorCode.getCode(), errorCode.getMessage()));
     }
 
     // [8] 접근 권한 없음 (인가 실패)
@@ -98,6 +98,6 @@ public class GlobalExceptionHandler {
         ErrorCode errorCode = ErrorCode.ACCESS_DENIED;
         return ResponseEntity
                 .status(errorCode.getHttpStatus())
-                .body(CommonResponse.createError(errorCode.getCode(), errorCode.getMessage()));
+                .body(CommonResponse.createError(errorCode.getHttpStatus(), errorCode.getCode(), errorCode.getMessage()));
     }
 }

--- a/cubco-common/src/main/java/org/cubco/response/CommonResponse.java
+++ b/cubco-common/src/main/java/org/cubco/response/CommonResponse.java
@@ -3,6 +3,7 @@ package org.cubco.response;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 
@@ -12,49 +13,71 @@ import java.util.Map;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CommonResponse<T> {
-    private static final String SUCCESS_STATUS = "success";
-    private static final String ERROR_STATUS = "error";
 
-    private String status; // success, error
-    private T data; // 성공 데이터 or 에러 상세정보
-    private String message; // 사용자 메시지
+    private int status;            // HTTP 상태 코드 (200, 400, 404 등)
+    private String code;           // 비즈니스 에러 코드 (ex: "USER_NOT_FOUND")
+    private String message;        // 사용자 또는 클라이언트에게 보여줄 메시지
+    private T data;                // 실제 응답 데이터 (성공일 경우에만 포함)
 
-    // 일반적인 성공 응답 생성 (데이터 포함)
-    public static <T> CommonResponse<T> createSuccess(String message, T data) {
-        return new CommonResponse<>(SUCCESS_STATUS, message, data);
+    // 성공 응답 생성 (데이터와 메시지 포함)
+    public static <T> CommonResponse<T> createSuccess(HttpStatus httpStatus, String message, T data) {
+        return new CommonResponse<>(httpStatus.value(), message, data);
     }
 
-    // 응답 데이터 없이 성공 메시지만 반환
-    public static CommonResponse<?> createSuccessWithNoContent(String message) {
-        return new CommonResponse<>(SUCCESS_STATUS, message, null);
+    // 성공 응답 생성 (데이터 없음, 메시지만 있는 경우)
+    public static CommonResponse<?> createSuccessWithNoContent(HttpStatus httpStatus, String message) {
+        return new CommonResponse<>(httpStatus.value(), message);
     }
 
-    // 기본 에러 응답 생성 (에러 메시지만 포함, 코드 없음)
+    // 에러 응답 생성 (message만 포함)
     public static CommonResponse<?> createError(String message) {
-        return new CommonResponse<>(ERROR_STATUS, message, null);
+        return new CommonResponse<>(message);
     }
 
-    // 에러 코드와 메시지를 포함한 에러 응답 생성
-    public static CommonResponse<?> createError(String code, String message) {
-        Map<String, String> errorData = new HashMap<>();
-        errorData.put("code", code);
-        errorData.put("message", message);
-        return new CommonResponse<>(ERROR_STATUS, message, errorData);
+    // 에러 응답 생성 (status, code, message 포함)
+    public static CommonResponse<?> createError(HttpStatus httpStatus, String code, String message) {
+        return new CommonResponse<>(httpStatus.value(), code, message);
     }
 
-    // 유효성 검증 실패 응답 생성 (필드별 에러 메시지 포함)
+    // 유효성 검사 실패 시 필드별 에러 메시지 포함한 응답 생성
     public static CommonResponse<?> createValidationError(BindingResult bindingResult) {
         Map<String, String> fieldErrors = new HashMap<>();
         for (FieldError fieldError : bindingResult.getFieldErrors()) {
             fieldErrors.put(fieldError.getField(), fieldError.getDefaultMessage());
         }
-        return new CommonResponse<>(ERROR_STATUS, "요청 데이터가 유효하지 않습니다.", fieldErrors);
+        return new CommonResponse<>(HttpStatus.BAD_REQUEST.value(), "VALIDATION_FAILED", "요청 데이터가 유효하지 않습니다.", fieldErrors);
     }
 
-    // 생성자 - 내부에서만 사용, 공통 응답 구조 초기화
-    private CommonResponse(String status, String message, T data) {
+    // 생성자: 성공 응답용 (data 포함)
+    private CommonResponse(int status, String message, T data) {
         this.status = status;
         this.message = message;
         this.data = data;
+    }
+
+    // 생성자: 성공 응답용
+    private CommonResponse(int status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+
+    // 생성자: 에러 응답용 (code, message, data 포함)
+    private CommonResponse(int status, String code, String message, T data) {
+        this.status = status;
+        this.code = code;
+        this.message = message;
+        this.data = data;
+    }
+
+    // 생성자: 에러 응답용 (code, message만 포함)
+    private CommonResponse(int status, String code, String message) {
+        this.status = status;
+        this.code = code;
+        this.message = message;
+    }
+
+    // 생성자: 에러 응답용 (message만 포함)
+    private CommonResponse(String message) {
+        this.message = message;
     }
 }


### PR DESCRIPTION
## 🔥*Pull requests*

#️⃣️ **작업한 브랜치**
- chore/#20

📄  **작업한 내용**
<!-- 작업에 대한 간략한 설명 -->
### 1. 공통 응답 객체(`CommonResponse`) 구조 변경
- 기존의 status는 `success`, `error`를 나타내 주는 방식 -> HTTP status(200, 400, 401, 403 등등)로 변경
- `private String code` 필드 추가 - 기존 방식은 errorData인 Map에 에러 코드를 담아서 사용 하는 방식 -> code 필드로 에러코드 활용

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
`private int status;`            // HTTP 상태 코드 (200, 400, 404 등)
`private String code;`           // 비즈니스 에러 코드 (ex: "USER_NOT_FOUND")
`private String message;`        // 사용자 또는 클라이언트에게 보여줄 메시지
`private T data;`                // 실제 응답 데이터 (성공일 경우에만 포함)

## 💻 관련 이슈
- Resolved: #20

## 💬 리뷰 요구사항 (선택)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->
- 혹시 `CustomAccessDeniedHandler` 클래스에 `CommonResponse<?> errorResponse = CommonResponse.createError("접근 권한이 없습니다");` 라는 코드가 있길래 `CommonResponse` 클래스에 아래 코드를 추가했는데 맞게 구현한건지 한번 봐주실 수 있나요?
```
public static CommonResponse<?> createError(String message) {
        return new CommonResponse<>(message);
    }


    private CommonResponse(String message) {
        this.message = message;
    }
```