### PR TITLE
[FEAT] 쿠폰 API 구현 - #19

### DIFF
--- a/cubco-api/build.gradle
+++ b/cubco-api/build.gradle
@@ -3,6 +3,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'io.jsonwebtoken:jjwt:0.12.3'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.4.0' // Swagger
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa' // JPA
+
 
     implementation project(path: ':cubco-common')
     implementation project(path: ':cubco-domain')

--- a/cubco-api/src/main/java/org/cubco/config/SecurityConfig.java
+++ b/cubco-api/src/main/java/org/cubco/config/SecurityConfig.java
@@ -60,7 +60,8 @@ public class SecurityConfig {
                                 "/swagger-ui.html",
                                 "/v3/api-docs/**",
                                 "/swagger-resources/**",
-                                "/test/jwt"
+                                "/test/jwt",
+                                "/api/v1/**" // 개발 완료 후 변경 예정
                         ).permitAll()
                         .anyRequest().hasRole("ADMIN"))
                 .addFilterBefore(new JwtAuthenticationFilter(jwTutil), UsernamePasswordAuthenticationFilter.class);

--- a/cubco-api/src/main/java/org/cubco/controller/CouponController.java
+++ b/cubco-api/src/main/java/org/cubco/controller/CouponController.java
@@ -1,0 +1,65 @@
+package org.cubco.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.cubco.dto.coupon.CouponDetailResponse;
+import org.cubco.dto.coupon.CouponImageUpdateRequest;
+import org.cubco.dto.coupon.CouponResponse;
+import org.cubco.dto.coupon.CouponUseRequest;
+import org.cubco.response.CommonResponse;
+import org.cubco.service.CouponService;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/coupons")
+public class CouponController {
+
+    private final CouponService couponService;
+
+    // 1. 사용자 보유 쿠폰 리스트 조회
+    @GetMapping("/list")
+//    public CommonResponse<List<CouponListResponse>> getUserCoupons(@UserId Long userId) { // PR 후 주석해제
+    public CommonResponse<List<CouponResponse>> getUserCoupons(Long userId) {
+        List<CouponResponse> coupons = couponService.getCouponsByUser(userId);
+        return CommonResponse.createSuccess(HttpStatus.OK, "보유 쿠폰 목록 조회 성공", coupons);
+    }
+
+    // 2. 쿠폰 상세 조회
+    @GetMapping("/{couponId}")
+    public CommonResponse<CouponDetailResponse> getCouponDetail(
+//            @UserId Long userId, // PR 후 주석해제
+            Long userId,
+            @PathVariable Long couponId
+    ) {
+        CouponDetailResponse detail = couponService.getCouponDetail(userId, couponId);
+        return CommonResponse.createSuccess(HttpStatus.OK, "쿠폰 상세 조회 성공", detail);
+    }
+
+    // 3. 쿠폰 이미지 변경
+    @PatchMapping("/{couponId}/image")
+    public CommonResponse<?> updateCouponImage(
+//            @UserId Long userId, // PR 후 주석 해제
+            Long userId,
+            @PathVariable Long couponId,
+            @RequestBody CouponImageUpdateRequest request
+    ) {
+        couponService.updateCouponImage(userId, couponId, request.getImageUrl());
+        return CommonResponse.createSuccessWithNoContent(HttpStatus.OK, "쿠폰 이미지가 변경되었습니다.");
+    }
+
+    // 4. 쿠폰 사용 (count 차감)
+    @PatchMapping("/{couponId}/use")
+    public CommonResponse<?> useCoupon(
+//            @UserId Long userId, // PR 후 주석 해제
+            Long userId,
+            @PathVariable Long couponId,
+            @RequestBody CouponUseRequest request
+    ) {
+        couponService.useCoupon(userId, couponId, request.getCount());
+        return CommonResponse.createSuccessWithNoContent(HttpStatus.OK, "쿠폰이 사용되었습니다.");
+    }
+
+}

--- a/cubco-api/src/main/java/org/cubco/controller/CouponController.java
+++ b/cubco-api/src/main/java/org/cubco/controller/CouponController.java
@@ -1,21 +1,24 @@
 package org.cubco.controller;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.cubco.dto.coupon.CouponDetailResponse;
 import org.cubco.dto.coupon.CouponImageUpdateRequest;
 import org.cubco.dto.coupon.CouponResponse;
 import org.cubco.dto.coupon.CouponUseRequest;
 import org.cubco.response.CommonResponse;
 import org.cubco.service.CouponService;
+import org.cubco.swagger.CouponApiDocs;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/coupons")
-public class CouponController {
+public class CouponController implements CouponApiDocs {
 
     private final CouponService couponService;
 
@@ -34,8 +37,8 @@ public class CouponController {
             Long userId,
             @PathVariable Long couponId
     ) {
-        CouponDetailResponse detail = couponService.getCouponDetail(userId, couponId);
-        return CommonResponse.createSuccess(HttpStatus.OK, "쿠폰 상세 조회 성공", detail);
+        CouponDetailResponse coupon = couponService.getCouponDetail(userId, couponId);
+        return CommonResponse.createSuccess(HttpStatus.OK, "쿠폰 상세 조회 성공", coupon);
     }
 
     // 3. 쿠폰 이미지 변경
@@ -46,8 +49,8 @@ public class CouponController {
             @PathVariable Long couponId,
             @RequestBody CouponImageUpdateRequest request
     ) {
-        couponService.updateCouponImage(userId, couponId, request.getImageUrl());
-        return CommonResponse.createSuccessWithNoContent(HttpStatus.OK, "쿠폰 이미지가 변경되었습니다.");
+        CouponDetailResponse coupon = couponService.updateCouponImage(userId, couponId, request.getImageUrl());
+        return CommonResponse.createSuccess(HttpStatus.OK, "쿠폰 이미지가 변경되었습니다.", coupon);
     }
 
     // 4. 쿠폰 사용 (count 차감)

--- a/cubco-api/src/main/java/org/cubco/controller/CouponController.java
+++ b/cubco-api/src/main/java/org/cubco/controller/CouponController.java
@@ -2,10 +2,7 @@ package org.cubco.controller;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.cubco.dto.coupon.CouponDetailResponse;
-import org.cubco.dto.coupon.CouponImageUpdateRequest;
-import org.cubco.dto.coupon.CouponResponse;
-import org.cubco.dto.coupon.CouponUseRequest;
+import org.cubco.dto.coupon.*;
 import org.cubco.response.CommonResponse;
 import org.cubco.service.CouponService;
 import org.cubco.swagger.CouponApiDocs;
@@ -49,7 +46,7 @@ public class CouponController implements CouponApiDocs {
             @PathVariable Long couponId,
             @RequestBody CouponImageUpdateRequest request
     ) {
-        CouponDetailResponse coupon = couponService.updateCouponImage(userId, couponId, request.getImageUrl());
+        CouponImageUpdateResponse coupon = couponService.updateCouponImage(userId, couponId, request.getImageUrl());
         return CommonResponse.createSuccess(HttpStatus.OK, "쿠폰 이미지가 변경되었습니다.", coupon);
     }
 
@@ -61,8 +58,8 @@ public class CouponController implements CouponApiDocs {
             @PathVariable Long couponId,
             @RequestBody CouponUseRequest request
     ) {
-        couponService.useCoupon(userId, couponId, request.getCount());
-        return CommonResponse.createSuccessWithNoContent(HttpStatus.OK, "쿠폰이 사용되었습니다.");
+        CouponUseResponse coupon = couponService.useCoupon(userId, couponId, request.getCount());
+        return CommonResponse.createSuccess(HttpStatus.OK, "쿠폰이 사용되었습니다.", coupon);
     }
 
 }

--- a/cubco-api/src/main/java/org/cubco/controller/CouponController.java
+++ b/cubco-api/src/main/java/org/cubco/controller/CouponController.java
@@ -1,5 +1,6 @@
 package org.cubco.controller;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.cubco.dto.coupon.*;
@@ -44,7 +45,7 @@ public class CouponController implements CouponApiDocs {
 //            @UserId Long userId, // PR 후 주석 해제
             Long userId,
             @PathVariable Long couponId,
-            @RequestBody CouponImageUpdateRequest request
+            @RequestBody @Valid CouponImageUpdateRequest request
     ) {
         CouponImageUpdateResponse coupon = couponService.updateCouponImage(userId, couponId, request.getImageUrl());
         return CommonResponse.createSuccess(HttpStatus.OK, "쿠폰 이미지가 변경되었습니다.", coupon);
@@ -56,7 +57,7 @@ public class CouponController implements CouponApiDocs {
 //            @UserId Long userId, // PR 후 주석 해제
             Long userId,
             @PathVariable Long couponId,
-            @RequestBody CouponUseRequest request
+            @RequestBody @Valid CouponUseRequest request
     ) {
         CouponUseResponse coupon = couponService.useCoupon(userId, couponId, request.getCount());
         return CommonResponse.createSuccess(HttpStatus.OK, "쿠폰이 사용되었습니다.", coupon);

--- a/cubco-api/src/main/java/org/cubco/controller/TestController.java
+++ b/cubco-api/src/main/java/org/cubco/controller/TestController.java
@@ -1,28 +1,28 @@
-//package org.cubco.controller;
-//
-//import io.swagger.v3.oas.annotations.Operation;
-//import io.swagger.v3.oas.annotations.responses.ApiResponse;
-//import io.swagger.v3.oas.annotations.responses.ApiResponses;
-//import org.cubco.response.CommonResponse;
-//import org.cubco.exception.CustomException;
-//import org.cubco.exception.ErrorCode;
-//import org.cubco.swagger.TestApiDocs;
-//import org.springframework.http.HttpStatus;
-//import org.springframework.web.bind.annotation.GetMapping;
-//import org.springframework.web.bind.annotation.RequestMapping;
-//import org.springframework.web.bind.annotation.RestController;
-//
-//@RestController
-//@RequestMapping("/test")
-//public class TestController implements TestApiDocs {
-//
-//    @GetMapping("/success")
-//    public CommonResponse<?> createUser() {
-//        return CommonResponse.createSuccess(HttpStatus.OK ,"성공", "data");
-//    }
-//
-//    @GetMapping("/error")
-//    public CommonResponse<Void> error() {
-//        throw new CustomException(ErrorCode.INVALID_REQUEST) {};
-//    }
-//}
+package org.cubco.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.cubco.response.CommonResponse;
+import org.cubco.exception.CustomException;
+import org.cubco.exception.ErrorCode;
+import org.cubco.swagger.TestApiDocs;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/test")
+public class TestController implements TestApiDocs {
+
+    @GetMapping("/success")
+    public CommonResponse<?> createUser() {
+        return CommonResponse.createSuccess(HttpStatus.OK ,"성공", "data");
+    }
+
+    @GetMapping("/error")
+    public CommonResponse<Void> error() {
+        throw new CustomException(ErrorCode.INVALID_REQUEST) {};
+    }
+}

--- a/cubco-api/src/main/java/org/cubco/controller/TestController.java
+++ b/cubco-api/src/main/java/org/cubco/controller/TestController.java
@@ -1,33 +1,21 @@
 package org.cubco.controller;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.cubco.response.CommonResponse;
 import org.cubco.exception.CustomException;
 import org.cubco.exception.ErrorCode;
+import org.cubco.swagger.TestApiDocs;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/test")
-public class TestController {
+public class TestController implements TestApiDocs {
 
-    @Operation(summary = "Response 테스트", description = "공통 응답 객체가 잘 동작하는지 확인합니다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "요청 성공")
-    })
     @GetMapping("/success")
     public CommonResponse<?> createUser() {
         return CommonResponse.createSuccessWithNoContent("성공");
     }
-
-    @Operation(summary = "예외 응답 테스트", description = "예외 발생 시 GlobalExceptionHandler가 작동하는지 확인합니다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
-            @ApiResponse(responseCode = "500", description = "서버 내부 오류")
-    })
 
     @GetMapping("/error")
     public CommonResponse<Void> error() {

--- a/cubco-api/src/main/java/org/cubco/controller/TestController.java
+++ b/cubco-api/src/main/java/org/cubco/controller/TestController.java
@@ -1,28 +1,28 @@
-package org.cubco.controller;
-
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import org.cubco.response.CommonResponse;
-import org.cubco.exception.CustomException;
-import org.cubco.exception.ErrorCode;
-import org.cubco.swagger.TestApiDocs;
-import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
-@RestController
-@RequestMapping("/test")
-public class TestController implements TestApiDocs {
-
-    @GetMapping("/success")
-    public CommonResponse<?> createUser() {
-        return CommonResponse.createSuccess(HttpStatus.OK ,"성공", "data");
-    }
-
-    @GetMapping("/error")
-    public CommonResponse<Void> error() {
-        throw new CustomException(ErrorCode.INVALID_REQUEST) {};
-    }
-}
+//package org.cubco.controller;
+//
+//import io.swagger.v3.oas.annotations.Operation;
+//import io.swagger.v3.oas.annotations.responses.ApiResponse;
+//import io.swagger.v3.oas.annotations.responses.ApiResponses;
+//import org.cubco.response.CommonResponse;
+//import org.cubco.exception.CustomException;
+//import org.cubco.exception.ErrorCode;
+//import org.cubco.swagger.TestApiDocs;
+//import org.springframework.http.HttpStatus;
+//import org.springframework.web.bind.annotation.GetMapping;
+//import org.springframework.web.bind.annotation.RequestMapping;
+//import org.springframework.web.bind.annotation.RestController;
+//
+//@RestController
+//@RequestMapping("/test")
+//public class TestController implements TestApiDocs {
+//
+//    @GetMapping("/success")
+//    public CommonResponse<?> createUser() {
+//        return CommonResponse.createSuccess(HttpStatus.OK ,"성공", "data");
+//    }
+//
+//    @GetMapping("/error")
+//    public CommonResponse<Void> error() {
+//        throw new CustomException(ErrorCode.INVALID_REQUEST) {};
+//    }
+//}

--- a/cubco-api/src/main/java/org/cubco/controller/TestController.java
+++ b/cubco-api/src/main/java/org/cubco/controller/TestController.java
@@ -7,6 +7,7 @@
 //import org.cubco.exception.CustomException;
 //import org.cubco.exception.ErrorCode;
 //import org.cubco.swagger.TestApiDocs;
+//import org.springframework.http.HttpStatus;
 //import org.springframework.web.bind.annotation.GetMapping;
 //import org.springframework.web.bind.annotation.RequestMapping;
 //import org.springframework.web.bind.annotation.RestController;
@@ -17,7 +18,7 @@
 //
 //    @GetMapping("/success")
 //    public CommonResponse<?> createUser() {
-//        return CommonResponse.createSuccessWithNoContent("성공");
+//        return CommonResponse.createSuccess(HttpStatus.OK ,"성공", "data");
 //    }
 //
 //    @GetMapping("/error")

--- a/cubco-api/src/main/java/org/cubco/dto/coupon/CouponDetailResponse.java
+++ b/cubco-api/src/main/java/org/cubco/dto/coupon/CouponDetailResponse.java
@@ -1,0 +1,23 @@
+package org.cubco.dto.coupon;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.cubco.coupon.domain.Coupon;
+
+@Getter
+@AllArgsConstructor
+public class CouponDetailResponse {
+    private Long couponId;
+    private int count;
+    private String imageUrl;
+    private Long cafeId;
+
+    public static CouponDetailResponse of(Coupon coupon) {
+        return new CouponDetailResponse(
+                coupon.getId(),
+                coupon.getCount(),
+                coupon.getImageUrl(),
+                coupon.getCafe().getId()
+        );
+    }
+}

--- a/cubco-api/src/main/java/org/cubco/dto/coupon/CouponDetailResponse.java
+++ b/cubco-api/src/main/java/org/cubco/dto/coupon/CouponDetailResponse.java
@@ -8,16 +8,16 @@ import org.cubco.coupon.domain.Coupon;
 @AllArgsConstructor
 public class CouponDetailResponse {
     private Long couponId;
-    private int count;
-    private String imageUrl;
     private Long cafeId;
+    private int stampCount;
+    private String couponImageUrl;
 
     public static CouponDetailResponse of(Coupon coupon) {
         return new CouponDetailResponse(
                 coupon.getId(),
+                coupon.getCafe().getId(),
                 coupon.getCount(),
-                coupon.getImageUrl(),
-                coupon.getCafe().getId()
+                coupon.getImageUrl()
         );
     }
 }

--- a/cubco-api/src/main/java/org/cubco/dto/coupon/CouponImageUpdateRequest.java
+++ b/cubco-api/src/main/java/org/cubco/dto/coupon/CouponImageUpdateRequest.java
@@ -1,5 +1,6 @@
 package org.cubco.dto.coupon;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.cubco.coupon.domain.Coupon;
@@ -7,6 +8,8 @@ import org.cubco.coupon.domain.Coupon;
 @Getter
 @AllArgsConstructor
 public class CouponImageUpdateRequest {
+
+    @Schema(description = "변경할 이미지 URL", example = "https://img.com/sample.jpg")
     private String imageUrl;
 
     public static CouponImageUpdateRequest of(Coupon coupon) {

--- a/cubco-api/src/main/java/org/cubco/dto/coupon/CouponImageUpdateRequest.java
+++ b/cubco-api/src/main/java/org/cubco/dto/coupon/CouponImageUpdateRequest.java
@@ -1,20 +1,16 @@
 package org.cubco.dto.coupon;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import org.cubco.coupon.domain.Coupon;
 
 @Getter
 @AllArgsConstructor
 public class CouponImageUpdateRequest {
 
+    @NotBlank(message = "변경할 이미지 파일이 없습니다.")
     @Schema(description = "변경할 이미지 URL", example = "https://img.com/sample.jpg")
     private String imageUrl;
 
-    public static CouponImageUpdateRequest of(Coupon coupon) {
-        return new CouponImageUpdateRequest(
-                coupon.getImageUrl()
-        );
-    }
 }

--- a/cubco-api/src/main/java/org/cubco/dto/coupon/CouponImageUpdateRequest.java
+++ b/cubco-api/src/main/java/org/cubco/dto/coupon/CouponImageUpdateRequest.java
@@ -1,0 +1,17 @@
+package org.cubco.dto.coupon;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.cubco.coupon.domain.Coupon;
+
+@Getter
+@AllArgsConstructor
+public class CouponImageUpdateRequest {
+    private String imageUrl;
+
+    public static CouponImageUpdateRequest of(Coupon coupon) {
+        return new CouponImageUpdateRequest(
+                coupon.getImageUrl()
+        );
+    }
+}

--- a/cubco-api/src/main/java/org/cubco/dto/coupon/CouponImageUpdateResponse.java
+++ b/cubco-api/src/main/java/org/cubco/dto/coupon/CouponImageUpdateResponse.java
@@ -1,29 +1,23 @@
 package org.cubco.dto.coupon;
 
-
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.cubco.coupon.domain.Coupon;
 
-import java.time.LocalDateTime;
-
 @Getter
 @AllArgsConstructor
-public class CouponResponse {
-
+public class CouponImageUpdateResponse {
     private Long couponId;
     private Long cafeId;
     private int stampCount;
     private String couponImageUrl;
-    private LocalDateTime lastUpdated;
 
-    public static CouponResponse of(Coupon coupon) {
-        return new CouponResponse(
+    public static CouponImageUpdateResponse of(Coupon coupon) {
+        return new CouponImageUpdateResponse(
                 coupon.getId(),
                 coupon.getCafe().getId(),
                 coupon.getCount(),
-                coupon.getImageUrl(),
-                coupon.getModifiedAt()
+                coupon.getImageUrl()
         );
     }
 }

--- a/cubco-api/src/main/java/org/cubco/dto/coupon/CouponResponse.java
+++ b/cubco-api/src/main/java/org/cubco/dto/coupon/CouponResponse.java
@@ -1,0 +1,23 @@
+package org.cubco.dto.coupon;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.cubco.coupon.domain.Coupon;
+
+@Getter
+@AllArgsConstructor
+public class CouponResponse {
+
+    private Long couponId;
+    private String imageUrl;
+    private int count;
+
+    public static CouponResponse of(Coupon coupon) {
+        return new CouponResponse(
+                coupon.getId(),
+                coupon.getImageUrl(),
+                coupon.getCount()
+        );
+    }
+}

--- a/cubco-api/src/main/java/org/cubco/dto/coupon/CouponUseRequest.java
+++ b/cubco-api/src/main/java/org/cubco/dto/coupon/CouponUseRequest.java
@@ -1,5 +1,6 @@
 package org.cubco.dto.coupon;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import lombok.AllArgsConstructor;
@@ -12,6 +13,7 @@ public class CouponUseRequest {
 
     @Min(1)
     @Max(10)
+    @Schema(description = "차감할 count", example = "5")
     private int count;
 
     public static CouponUseRequest of(Coupon coupon) {

--- a/cubco-api/src/main/java/org/cubco/dto/coupon/CouponUseRequest.java
+++ b/cubco-api/src/main/java/org/cubco/dto/coupon/CouponUseRequest.java
@@ -3,6 +3,7 @@ package org.cubco.dto.coupon;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.cubco.coupon.domain.Coupon;
@@ -11,15 +12,9 @@ import org.cubco.coupon.domain.Coupon;
 @AllArgsConstructor
 public class CouponUseRequest {
 
-    @Min(1)
-    @Max(10)
+    @Min(value = 1,  message = "1개 이상 입력해야 합니다.")
+    @Max(value = 10, message = "최대 10개까지 가능합니다.")
     @Schema(description = "차감할 count", example = "5")
     private int count;
-
-    public static CouponUseRequest of(Coupon coupon) {
-        return new CouponUseRequest(
-                coupon.getCount()
-        );
-    }
 
 }

--- a/cubco-api/src/main/java/org/cubco/dto/coupon/CouponUseRequest.java
+++ b/cubco-api/src/main/java/org/cubco/dto/coupon/CouponUseRequest.java
@@ -1,0 +1,23 @@
+package org.cubco.dto.coupon;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.cubco.coupon.domain.Coupon;
+
+@Getter
+@AllArgsConstructor
+public class CouponUseRequest {
+
+    @Min(1)
+    @Max(10)
+    private int count;
+
+    public static CouponUseRequest of(Coupon coupon) {
+        return new CouponUseRequest(
+                coupon.getCount()
+        );
+    }
+
+}

--- a/cubco-api/src/main/java/org/cubco/dto/coupon/CouponUseResponse.java
+++ b/cubco-api/src/main/java/org/cubco/dto/coupon/CouponUseResponse.java
@@ -1,29 +1,23 @@
 package org.cubco.dto.coupon;
 
-
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.cubco.coupon.domain.Coupon;
 
-import java.time.LocalDateTime;
-
 @Getter
 @AllArgsConstructor
-public class CouponResponse {
-
+public class CouponUseResponse {
     private Long couponId;
     private Long cafeId;
     private int stampCount;
     private String couponImageUrl;
-    private LocalDateTime lastUpdated;
 
-    public static CouponResponse of(Coupon coupon) {
-        return new CouponResponse(
+    public static CouponUseResponse of(Coupon coupon) {
+        return new CouponUseResponse(
                 coupon.getId(),
                 coupon.getCafe().getId(),
                 coupon.getCount(),
-                coupon.getImageUrl(),
-                coupon.getModifiedAt()
+                coupon.getImageUrl()
         );
     }
 }

--- a/cubco-api/src/main/java/org/cubco/exception/GlobalExceptionHandler.java
+++ b/cubco-api/src/main/java/org/cubco/exception/GlobalExceptionHandler.java
@@ -28,7 +28,7 @@ public class GlobalExceptionHandler {
         ErrorCode errorCode = ex.getErrorCode();
         return ResponseEntity
                 .status(errorCode.getHttpStatus())
-                .body(CommonResponse.createError(errorCode.getCode(), errorCode.getMessage()));
+                .body(CommonResponse.createError(errorCode.getHttpStatus(), errorCode.getCode(), errorCode.getMessage()));
     }
 
     // [2] 예상치 못한 서버 내부 예외 처리
@@ -38,7 +38,7 @@ public class GlobalExceptionHandler {
         ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
         return ResponseEntity
                 .status(errorCode.getHttpStatus())
-                .body(CommonResponse.createError(errorCode.getCode(), errorCode.getMessage()));
+                .body(CommonResponse.createError(errorCode.getHttpStatus(), errorCode.getCode(), errorCode.getMessage()));
     }
 
     // [3] DTO 유효성 검사 실패 (ex: @Valid)
@@ -58,7 +58,7 @@ public class GlobalExceptionHandler {
         ErrorCode errorCode = ErrorCode.METHOD_NOT_ALLOWED;
         return ResponseEntity
                 .status(errorCode.getHttpStatus())
-                .body(CommonResponse.createError(errorCode.getCode(), errorCode.getMessage()));
+                .body(CommonResponse.createError(errorCode.getHttpStatus(), errorCode.getCode(), errorCode.getMessage()));
     }
 
     // [5] JSON 파싱 오류 (ex: 잘못된 형식의 JSON Body)
@@ -68,7 +68,7 @@ public class GlobalExceptionHandler {
         ErrorCode errorCode = ErrorCode.INVALID_REQUEST;
         return ResponseEntity
                 .status(errorCode.getHttpStatus())
-                .body(CommonResponse.createError(errorCode.getCode(), errorCode.getMessage()));
+                .body(CommonResponse.createError(errorCode.getHttpStatus(), errorCode.getCode(), errorCode.getMessage()));
     }
 
     // [6] 필수 쿼리 파라미터 누락
@@ -78,7 +78,7 @@ public class GlobalExceptionHandler {
         ErrorCode errorCode = ErrorCode.MISSING_REQUIRED_FIELD;
         return ResponseEntity
                 .status(errorCode.getHttpStatus())
-                .body(CommonResponse.createError(errorCode.getCode(), errorCode.getMessage()));
+                .body(CommonResponse.createError(errorCode.getHttpStatus(), errorCode.getCode(), errorCode.getMessage()));
     }
 
     // [7] 단일 필드 유효성 검증 실패 (ex: @RequestParam 검증)
@@ -88,7 +88,7 @@ public class GlobalExceptionHandler {
         ErrorCode errorCode = ErrorCode.INVALID_INPUT_VALUE;
         return ResponseEntity
                 .status(errorCode.getHttpStatus())
-                .body(CommonResponse.createError(errorCode.getCode(), errorCode.getMessage()));
+                .body(CommonResponse.createError(errorCode.getHttpStatus(), errorCode.getCode(), errorCode.getMessage()));
     }
 
     // [8] 접근 권한 없음 (인가 실패)
@@ -98,6 +98,6 @@ public class GlobalExceptionHandler {
         ErrorCode errorCode = ErrorCode.ACCESS_DENIED;
         return ResponseEntity
                 .status(errorCode.getHttpStatus())
-                .body(CommonResponse.createError(errorCode.getCode(), errorCode.getMessage()));
+                .body(CommonResponse.createError(errorCode.getHttpStatus(), errorCode.getCode(), errorCode.getMessage()));
     }
 }

--- a/cubco-api/src/main/java/org/cubco/exception/GlobalExceptionHandler.java
+++ b/cubco-api/src/main/java/org/cubco/exception/GlobalExceptionHandler.java
@@ -1,42 +1,103 @@
 package org.cubco.exception;
 
 import io.swagger.v3.oas.annotations.Hidden;
+import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
 import org.cubco.response.CommonResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.BindingResult;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import java.nio.file.AccessDeniedException;
+
+@Slf4j
 @Hidden
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    // 커스텀 예외 처리
+    // [1] 비즈니스 로직 관련 사용자 정의 예외 처리
     @ExceptionHandler(CustomException.class)
     public ResponseEntity<CommonResponse<?>> handleCustomException(CustomException ex) {
+        log.error("비즈니스 예외 발생", ex);
         ErrorCode errorCode = ex.getErrorCode();
         return ResponseEntity
                 .status(errorCode.getHttpStatus())
-                .body(CommonResponse.createError(errorCode.getMessage()));
+                .body(CommonResponse.createError(errorCode.getCode(), errorCode.getMessage()));
     }
 
-    // 그 외 예외 처리
+    // [2] 예상치 못한 서버 내부 예외 처리
     @ExceptionHandler(Exception.class)
     public ResponseEntity<CommonResponse<?>> handleException(Exception ex) {
+        log.error("서버 내부 예외 발생", ex);
         ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
         return ResponseEntity
                 .status(errorCode.getHttpStatus())
-                .body(CommonResponse.createError(errorCode.getMessage()));
+                .body(CommonResponse.createError(errorCode.getCode(), errorCode.getMessage()));
     }
 
-    // 유효성 검증 예외
+    // [3] DTO 유효성 검사 실패 (ex: @Valid)
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<CommonResponse<?>> handleValidationException(MethodArgumentNotValidException ex) {
+        log.error("DTO 유효성 검사 실패", ex);
         BindingResult bindingResult = ex.getBindingResult();
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
                 .body(CommonResponse.createValidationError(bindingResult));
+    }
+
+    // [4] 지원되지 않는 HTTP 메서드 (ex: GET 대신 POST 요청 등)
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<CommonResponse<?>> handleMethodNotSupported(HttpRequestMethodNotSupportedException ex) {
+        log.error("지원되지 않는 HTTP 메서드 요청", ex);
+        ErrorCode errorCode = ErrorCode.METHOD_NOT_ALLOWED;
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(CommonResponse.createError(errorCode.getCode(), errorCode.getMessage()));
+    }
+
+    // [5] JSON 파싱 오류 (ex: 잘못된 형식의 JSON Body)
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<CommonResponse<?>> handleMessageNotReadable(HttpMessageNotReadableException ex) {
+        log.error("요청 본문 파싱 실패", ex);
+        ErrorCode errorCode = ErrorCode.INVALID_REQUEST;
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(CommonResponse.createError(errorCode.getCode(), errorCode.getMessage()));
+    }
+
+    // [6] 필수 쿼리 파라미터 누락
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<CommonResponse<?>> handleMissingParameter(MissingServletRequestParameterException ex) {
+        log.error("필수 요청 파라미터 누락", ex);
+        ErrorCode errorCode = ErrorCode.MISSING_REQUIRED_FIELD;
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(CommonResponse.createError(errorCode.getCode(), errorCode.getMessage()));
+    }
+
+    // [7] 단일 필드 유효성 검증 실패 (ex: @RequestParam 검증)
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<CommonResponse<?>> handleConstraintViolation(ConstraintViolationException ex) {
+        log.error("필드 유효성 제약 위반", ex);
+        ErrorCode errorCode = ErrorCode.INVALID_INPUT_VALUE;
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(CommonResponse.createError(errorCode.getCode(), errorCode.getMessage()));
+    }
+
+    // [8] 접근 권한 없음 (인가 실패)
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<CommonResponse<?>> handleAccessDenied(AccessDeniedException ex) {
+        log.error("접근 권한 없음", ex);
+        ErrorCode errorCode = ErrorCode.ACCESS_DENIED;
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(CommonResponse.createError(errorCode.getCode(), errorCode.getMessage()));
     }
 }

--- a/cubco-api/src/main/java/org/cubco/exception/GlobalExceptionHandler.java
+++ b/cubco-api/src/main/java/org/cubco/exception/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
@@ -15,6 +16,8 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.nio.file.AccessDeniedException;
+import java.util.HashMap;
+import java.util.Map;
 
 @Slf4j
 @Hidden
@@ -46,6 +49,12 @@ public class GlobalExceptionHandler {
     public ResponseEntity<CommonResponse<?>> handleValidationException(MethodArgumentNotValidException ex) {
         log.error("DTO 유효성 검사 실패", ex);
         BindingResult bindingResult = ex.getBindingResult();
+
+        Map<String, String> fieldErrors = new HashMap<>();
+        for (FieldError fieldError : bindingResult.getFieldErrors()) {
+            fieldErrors.put(fieldError.getField(), fieldError.getDefaultMessage()); // ← 여기
+        }
+
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
                 .body(CommonResponse.createValidationError(bindingResult));

--- a/cubco-api/src/main/java/org/cubco/service/CouponService.java
+++ b/cubco-api/src/main/java/org/cubco/service/CouponService.java
@@ -1,6 +1,7 @@
 package org.cubco.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.cubco.coupon.domain.Coupon;
 import org.cubco.dto.coupon.CouponDetailResponse;
 import org.cubco.dto.coupon.CouponResponse;
@@ -9,7 +10,6 @@ import org.cubco.exception.CustomException;
 import org.cubco.exception.ErrorCode;
 import org.cubco.policy.CouponOwnershipPolicy;
 import org.cubco.policy.CouponRemainingCountPolicy;
-import org.cubco.policy.CouponUsePolicy;
 import org.cubco.repository.CouponRepository;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -17,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class CouponService {
@@ -46,7 +47,7 @@ public class CouponService {
 
     // [3] 쿠폰 이미지 수정
     @Transactional
-    public void updateCouponImage(Long userId, Long couponId, String imageUrl) {
+    public CouponDetailResponse updateCouponImage(Long userId, Long couponId, String imageUrl) {
         Coupon coupon = couponRepository.findById(couponId)
                 .orElseThrow(() -> new CouponNotFoundException());
 
@@ -54,16 +55,19 @@ public class CouponService {
         ownershipPolicy.validateCouponOwner(coupon, userId);
 
         coupon.updateImage(imageUrl);
+
+        return CouponDetailResponse.of(coupon);
     }
 
     // [4] 쿠폰 사용 처리 (count 차감)
     @Transactional
-    public void useCoupon(Long userId, Long couponId, Integer count) {
+    public void useCoupon(Long userId, Long couponId, int count) {
         Coupon coupon = couponRepository.findByUserIdAndId(userId, couponId)
                 .orElseThrow(() -> new CouponNotFoundException());
 
-        // 수정 권한이 있는지 검증 + count수가 적절한지 검증
+        // 수정 권한이 있는지 검증
         ownershipPolicy.validateCouponOwner(coupon, userId);
+        // count 수가 적절한지 검증
         countPolicy.validateCouponCount(coupon, count);
 
         coupon.updateCount(count);

--- a/cubco-api/src/main/java/org/cubco/service/CouponService.java
+++ b/cubco-api/src/main/java/org/cubco/service/CouponService.java
@@ -4,7 +4,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.cubco.coupon.domain.Coupon;
 import org.cubco.dto.coupon.CouponDetailResponse;
+import org.cubco.dto.coupon.CouponImageUpdateResponse;
 import org.cubco.dto.coupon.CouponResponse;
+import org.cubco.dto.coupon.CouponUseResponse;
 import org.cubco.exception.CouponNotFoundException;
 import org.cubco.exception.CustomException;
 import org.cubco.exception.ErrorCode;
@@ -47,7 +49,7 @@ public class CouponService {
 
     // [3] 쿠폰 이미지 수정
     @Transactional
-    public CouponDetailResponse updateCouponImage(Long userId, Long couponId, String imageUrl) {
+    public CouponImageUpdateResponse updateCouponImage(Long userId, Long couponId, String imageUrl) {
         Coupon coupon = couponRepository.findById(couponId)
                 .orElseThrow(() -> new CouponNotFoundException());
 
@@ -56,12 +58,12 @@ public class CouponService {
 
         coupon.updateImage(imageUrl);
 
-        return CouponDetailResponse.of(coupon);
+        return CouponImageUpdateResponse.of(coupon);
     }
 
     // [4] 쿠폰 사용 처리 (count 차감)
     @Transactional
-    public void useCoupon(Long userId, Long couponId, int count) {
+    public CouponUseResponse useCoupon(Long userId, Long couponId, int count) {
         Coupon coupon = couponRepository.findByUserIdAndId(userId, couponId)
                 .orElseThrow(() -> new CouponNotFoundException());
 
@@ -71,6 +73,7 @@ public class CouponService {
         countPolicy.validateCouponCount(coupon, count);
 
         coupon.updateCount(count);
+        return CouponUseResponse.of(coupon);
     }
 
 }

--- a/cubco-api/src/main/java/org/cubco/service/CouponService.java
+++ b/cubco-api/src/main/java/org/cubco/service/CouponService.java
@@ -69,7 +69,7 @@ public class CouponService {
 
         // 수정 권한이 있는지 검증
         ownershipPolicy.validateCouponOwner(coupon, userId);
-        // count 수가 적절한지 검증
+        // count가 coupon의 stampCount보다 작은지 검증
         countPolicy.validateCouponCount(coupon, count);
 
         coupon.updateCount(count);

--- a/cubco-api/src/main/java/org/cubco/service/CouponService.java
+++ b/cubco-api/src/main/java/org/cubco/service/CouponService.java
@@ -1,0 +1,72 @@
+package org.cubco.service;
+
+import lombok.RequiredArgsConstructor;
+import org.cubco.coupon.domain.Coupon;
+import org.cubco.dto.coupon.CouponDetailResponse;
+import org.cubco.dto.coupon.CouponResponse;
+import org.cubco.exception.CouponNotFoundException;
+import org.cubco.exception.CustomException;
+import org.cubco.exception.ErrorCode;
+import org.cubco.policy.CouponOwnershipPolicy;
+import org.cubco.policy.CouponRemainingCountPolicy;
+import org.cubco.policy.CouponUsePolicy;
+import org.cubco.repository.CouponRepository;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CouponService {
+
+    private final CouponRepository couponRepository;
+    private final CouponRemainingCountPolicy countPolicy;
+    private final CouponOwnershipPolicy ownershipPolicy;
+
+    // [1] 사용자 보유 쿠폰 목록 조회
+    public List<CouponResponse> getCouponsByUser(Long userId) {
+        List<Coupon> coupons = couponRepository.findAllByUserId(userId);
+
+        if (coupons.isEmpty()) throw new CouponNotFoundException();
+
+        return coupons.stream()
+                .map(CouponResponse::of)
+                .toList();
+    }
+
+    // [2] 쿠폰 상세 조회
+    public CouponDetailResponse getCouponDetail(Long userId, Long couponId) {
+        Coupon coupon = couponRepository.findByUserIdAndId(userId, couponId)
+                .orElseThrow(() -> new CouponNotFoundException());
+
+        return CouponDetailResponse.of(coupon);
+    }
+
+    // [3] 쿠폰 이미지 수정
+    @Transactional
+    public void updateCouponImage(Long userId, Long couponId, String imageUrl) {
+        Coupon coupon = couponRepository.findById(couponId)
+                .orElseThrow(() -> new CouponNotFoundException());
+
+        // 수정 권한이 있는지 검증
+        ownershipPolicy.validateCouponOwner(coupon, userId);
+
+        coupon.updateImage(imageUrl);
+    }
+
+    // [4] 쿠폰 사용 처리 (count 차감)
+    @Transactional
+    public void useCoupon(Long userId, Long couponId, Integer count) {
+        Coupon coupon = couponRepository.findByUserIdAndId(userId, couponId)
+                .orElseThrow(() -> new CouponNotFoundException());
+
+        // 수정 권한이 있는지 검증 + count수가 적절한지 검증
+        ownershipPolicy.validateCouponOwner(coupon, userId);
+        countPolicy.validateCouponCount(coupon, count);
+
+        coupon.updateCount(count);
+    }
+
+}

--- a/cubco-api/src/main/java/org/cubco/swagger/CouponApiDocs.java
+++ b/cubco-api/src/main/java/org/cubco/swagger/CouponApiDocs.java
@@ -50,6 +50,7 @@ public interface CouponApiDocs {
     @Operation(summary = "쿠폰 이미지 변경", description = "쿠폰 이미지 변경이 잘 되는지 확인합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "쿠폰 이미지가 변경되었습니다."),
+            @ApiResponse(responseCode = "400", description = "요청데이터가 유효하지 않습니다."),
             @ApiResponse(responseCode = "401", description = "인증이 필요합니다."),
             @ApiResponse(responseCode = "403", description = "접근 권한이 없습니다."),
             @ApiResponse(responseCode = "404", description = "존재하는 쿠폰을 찾을 수 없습니다."),

--- a/cubco-api/src/main/java/org/cubco/swagger/CouponApiDocs.java
+++ b/cubco-api/src/main/java/org/cubco/swagger/CouponApiDocs.java
@@ -1,0 +1,83 @@
+package org.cubco.swagger;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.cubco.dto.coupon.CouponDetailResponse;
+import org.cubco.dto.coupon.CouponImageUpdateRequest;
+import org.cubco.dto.coupon.CouponResponse;
+import org.cubco.dto.coupon.CouponUseRequest;
+import org.cubco.response.CommonResponse;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.List;
+
+public interface CouponApiDocs {
+
+    // 1. 사용자 보유 쿠폰 리스트 조회
+    @Operation(summary = "사용자 보유 쿠폰 리스트 테스트", description = "사용자가 보유한 쿠폰 리스트들이 잘 조회되는지 확인합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "보유 쿠폰 목록 조회 성공",
+                    content = @Content(schema = @Schema(implementation = CouponResponse.class))
+            ),
+            @ApiResponse(responseCode = "401", description = "인증이 필요합니다"),
+            @ApiResponse(responseCode = "404", description = "존재하는 쿠폰을 찾을 수 없습니다."),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류가 발생했습니다.")
+    })
+    CommonResponse<List<CouponResponse>> getUserCoupons(Long userId);
+
+    // 2. 쿠폰 상세 조회
+    @Operation(summary = "쿠폰 상세 조회", description = "쿠폰 상세조회가 잘 되는지 확인합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "쿠폰 상세 조회 성공",
+                    content = @Content(schema = @Schema(implementation = CouponDetailResponse.class))
+            ),
+            @ApiResponse(responseCode = "401", description = "인증이 필요합니다"),
+            @ApiResponse(responseCode = "404", description = "존재하는 쿠폰을 찾을 수 없습니다."),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류가 발생했습니다.")
+    })
+    CommonResponse<CouponDetailResponse> getCouponDetail(
+//            @UserId Long userId, // PR 후 주석해제
+            Long userId,
+            @PathVariable Long couponId
+    );
+
+    // 3. 쿠폰 이미지 변경
+    @Operation(summary = "쿠폰 이미지 변경", description = "쿠폰 이미지 변경이 잘 되는지 확인합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "쿠폰 이미지가 변경되었습니다."),
+            @ApiResponse(responseCode = "401", description = "인증이 필요합니다."),
+            @ApiResponse(responseCode = "403", description = "접근 권한이 없습니다."),
+            @ApiResponse(responseCode = "404", description = "존재하는 쿠폰을 찾을 수 없습니다."),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류가 발생했습니다.")
+    })
+    CommonResponse<?> updateCouponImage(
+//            @UserId Long userId, // PR 후 주석 해제
+            Long userId,
+            @PathVariable Long couponId,
+            @RequestBody CouponImageUpdateRequest request
+    );
+
+    // 4. 쿠폰 사용 (count 차감)
+    @Operation(summary = "쿠폰 사용", description = "쿠폰 사용이 잘 되는지 확인합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "쿠폰이 사용되었습니다."),
+            @ApiResponse(responseCode = "400", description = "입력값이 유효하지 않습니다."),
+            @ApiResponse(responseCode = "401", description = "인증이 필요합니다."),
+            @ApiResponse(responseCode = "403", description = "접근 권한이 없습니다."),
+            @ApiResponse(responseCode = "404", description = "존재하는 쿠폰을 찾을 수 없습니다."),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류가 발생했습니다.")
+    })
+    CommonResponse<?> useCoupon(
+//            @UserId Long userId, // PR 후 주석 해제
+            Long userId,
+            @PathVariable Long couponId,
+            @RequestBody CouponUseRequest request
+    );
+}
+
+

--- a/cubco-api/src/main/java/org/cubco/swagger/TestApiDocs.java
+++ b/cubco-api/src/main/java/org/cubco/swagger/TestApiDocs.java
@@ -1,23 +1,23 @@
-//package org.cubco.swagger;
-//
-//import io.swagger.v3.oas.annotations.Operation;
-//import io.swagger.v3.oas.annotations.responses.ApiResponse;
-//import io.swagger.v3.oas.annotations.responses.ApiResponses;
-//import org.cubco.response.CommonResponse;
-//import org.springframework.http.ResponseEntity;
-//
-//public interface TestApiDocs {
-//
-//    @Operation(summary = "Response 테스트", description = "공통 응답 객체가 잘 동작하는지 확인합니다.")
-//    @ApiResponses({
-//            @ApiResponse(responseCode = "200", description = "요청 성공")
-//    })
-//    CommonResponse<?> createUser();
-//
-//    @Operation(summary = "예외 응답 테스트", description = "예외 발생 시 GlobalExceptionHandler가 작동하는지 확인합니다.")
-//    @ApiResponses({
-//            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
-//            @ApiResponse(responseCode = "500", description = "서버 내부 오류")
-//    })
-//    CommonResponse<Void> error();
-//}
+package org.cubco.swagger;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.cubco.response.CommonResponse;
+import org.springframework.http.ResponseEntity;
+
+public interface TestApiDocs {
+
+    @Operation(summary = "Response 테스트", description = "공통 응답 객체가 잘 동작하는지 확인합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "요청 성공")
+    })
+    CommonResponse<?> createUser();
+
+    @Operation(summary = "예외 응답 테스트", description = "예외 발생 시 GlobalExceptionHandler가 작동하는지 확인합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    })
+    CommonResponse<Void> error();
+}

--- a/cubco-api/src/main/java/org/cubco/swagger/TestApiDocs.java
+++ b/cubco-api/src/main/java/org/cubco/swagger/TestApiDocs.java
@@ -1,0 +1,23 @@
+package org.cubco.swagger;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.cubco.response.CommonResponse;
+import org.springframework.http.ResponseEntity;
+
+public interface TestApiDocs {
+
+    @Operation(summary = "Response 테스트", description = "공통 응답 객체가 잘 동작하는지 확인합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "요청 성공")
+    })
+    CommonResponse<?> createUser();
+
+    @Operation(summary = "예외 응답 테스트", description = "예외 발생 시 GlobalExceptionHandler가 작동하는지 확인합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    })
+    CommonResponse<Void> error();
+}

--- a/cubco-common/src/main/java/org/cubco/exception/CouponForbiddenException.java
+++ b/cubco-common/src/main/java/org/cubco/exception/CouponForbiddenException.java
@@ -1,7 +1,7 @@
 package org.cubco.exception;
 
 public class CouponForbiddenException extends CustomException {
-    public CouponForbiddenException(String message) {
+    public CouponForbiddenException() {
         super(ErrorCode.FORBIDDEN);
     }
 }

--- a/cubco-common/src/main/java/org/cubco/exception/CouponForbiddenException.java
+++ b/cubco-common/src/main/java/org/cubco/exception/CouponForbiddenException.java
@@ -1,0 +1,7 @@
+package org.cubco.exception;
+
+public class CouponForbiddenException extends CustomException {
+    public CouponForbiddenException(String message) {
+        super(ErrorCode.FORBIDDEN);
+    }
+}

--- a/cubco-common/src/main/java/org/cubco/exception/CouponInsufficientCountException.java
+++ b/cubco-common/src/main/java/org/cubco/exception/CouponInsufficientCountException.java
@@ -1,0 +1,7 @@
+package org.cubco.exception;
+
+public class CouponInsufficientCountException extends CustomException {
+    public CouponInsufficientCountException() {
+        super(ErrorCode.INVALID_INPUT_VALUE);
+    }
+}

--- a/cubco-common/src/main/java/org/cubco/exception/CouponNotFoundException.java
+++ b/cubco-common/src/main/java/org/cubco/exception/CouponNotFoundException.java
@@ -1,0 +1,7 @@
+package org.cubco.exception;
+
+public class CouponNotFoundException extends CustomException {
+    public CouponNotFoundException() {
+      super(ErrorCode.COUPON_NOT_FOUND);
+    }
+}

--- a/cubco-common/src/main/java/org/cubco/exception/ErrorCode.java
+++ b/cubco-common/src/main/java/org/cubco/exception/ErrorCode.java
@@ -11,7 +11,6 @@ public enum ErrorCode {
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "INVALID_INPUT_VALUE", "입력값이 유효하지 않습니다."),
     VALIDATION_FAILED(HttpStatus.BAD_REQUEST, "VALIDATION_FAILED", "요청 데이터가 유효하지 않습니다."),
 
-
     // 401 Unauthorized
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED", "인증이 필요합니다."),
     TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "TOKEN_EXPIRED", "토큰이 만료되었습니다."),
@@ -24,7 +23,7 @@ public enum ErrorCode {
     // 404 Not Found
     NOT_FOUND(HttpStatus.NOT_FOUND, "NOT_FOUND", "요청한 자원이 존재하지 않습니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_NOT_FOUND", "해당 사용자를 찾을 수 없습니다."),
-//    MENU_NOT_FOUND(HttpStatus.NOT_FOUND, "MENU_NOT_FOUND", "해당 메뉴를 찾을 수 없습니다."),
+    COUPON_NOT_FOUND(HttpStatus.NOT_FOUND, "COUPON_NOT_FOUND", "존재하는 쿠폰을 찾을 수 없습니다."),
 //    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST_NOT_FOUND", "해당 게시글을 찾을 수 없습니다."),
 
     // 405 Method Not Allowed

--- a/cubco-common/src/main/java/org/cubco/exception/ErrorCode.java
+++ b/cubco-common/src/main/java/org/cubco/exception/ErrorCode.java
@@ -27,6 +27,9 @@ public enum ErrorCode {
 //    MENU_NOT_FOUND(HttpStatus.NOT_FOUND, "MENU_NOT_FOUND", "해당 메뉴를 찾을 수 없습니다."),
 //    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST_NOT_FOUND", "해당 게시글을 찾을 수 없습니다."),
 
+    // 405 Method Not Allowed
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "METHOD_NOT_ALLOWED", "허용되지 않은 HTTP 메서드입니다."),
+
     // 500 Internal Server Error
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR", "서버 내부 오류가 발생했습니다."),
     UNKNOWN_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "UNKNOWN_ERROR", "예기치 못한 오류가 발생했습니다.");

--- a/cubco-common/src/main/java/org/cubco/response/CommonResponse.java
+++ b/cubco-common/src/main/java/org/cubco/response/CommonResponse.java
@@ -20,20 +20,30 @@ public class CommonResponse<T> {
     private T data; // 성공 데이터 or 에러 상세정보
     private String message; // 사용자 메시지
 
+    // 일반적인 성공 응답 생성 (데이터 포함)
     public static <T> CommonResponse<T> createSuccess(String message, T data) {
         return new CommonResponse<>(SUCCESS_STATUS, message, data);
     }
 
+    // 응답 데이터 없이 성공 메시지만 반환
     public static CommonResponse<?> createSuccessWithNoContent(String message) {
         return new CommonResponse<>(SUCCESS_STATUS, message, null);
     }
 
-    // 예외 발생으로 API 호출 실패시 반환
+    // 기본 에러 응답 생성 (에러 메시지만 포함, 코드 없음)
     public static CommonResponse<?> createError(String message) {
         return new CommonResponse<>(ERROR_STATUS, message, null);
     }
 
-    // 유효성 검증 예외
+    // 에러 코드와 메시지를 포함한 에러 응답 생성
+    public static CommonResponse<?> createError(String code, String message) {
+        Map<String, String> errorData = new HashMap<>();
+        errorData.put("code", code);
+        errorData.put("message", message);
+        return new CommonResponse<>(ERROR_STATUS, message, errorData);
+    }
+
+    // 유효성 검증 실패 응답 생성 (필드별 에러 메시지 포함)
     public static CommonResponse<?> createValidationError(BindingResult bindingResult) {
         Map<String, String> fieldErrors = new HashMap<>();
         for (FieldError fieldError : bindingResult.getFieldErrors()) {
@@ -42,6 +52,7 @@ public class CommonResponse<T> {
         return new CommonResponse<>(ERROR_STATUS, "요청 데이터가 유효하지 않습니다.", fieldErrors);
     }
 
+    // 생성자 - 내부에서만 사용, 공통 응답 구조 초기화
     private CommonResponse(String status, String message, T data) {
         this.status = status;
         this.message = message;

--- a/cubco-common/src/main/java/org/cubco/response/CommonResponse.java
+++ b/cubco-common/src/main/java/org/cubco/response/CommonResponse.java
@@ -3,6 +3,7 @@ package org.cubco.response;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 
@@ -12,49 +13,71 @@ import java.util.Map;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CommonResponse<T> {
-    private static final String SUCCESS_STATUS = "success";
-    private static final String ERROR_STATUS = "error";
 
-    private String status; // success, error
-    private T data; // 성공 데이터 or 에러 상세정보
-    private String message; // 사용자 메시지
+    private int status;            // HTTP 상태 코드 (200, 400, 404 등)
+    private String code;           // 비즈니스 에러 코드 (ex: "USER_NOT_FOUND")
+    private String message;        // 사용자 또는 클라이언트에게 보여줄 메시지
+    private T data;                // 실제 응답 데이터 (성공일 경우에만 포함)
 
-    // 일반적인 성공 응답 생성 (데이터 포함)
-    public static <T> CommonResponse<T> createSuccess(String message, T data) {
-        return new CommonResponse<>(SUCCESS_STATUS, message, data);
+    // 성공 응답 생성 (데이터와 메시지 포함)
+    public static <T> CommonResponse<T> createSuccess(HttpStatus httpStatus, String message, T data) {
+        return new CommonResponse<>(httpStatus.value(), message, data);
     }
 
-    // 응답 데이터 없이 성공 메시지만 반환
-    public static CommonResponse<?> createSuccessWithNoContent(String message) {
-        return new CommonResponse<>(SUCCESS_STATUS, message, null);
+    // 성공 응답 생성 (데이터 없음, 메시지만 있는 경우)
+    public static CommonResponse<?> createSuccessWithNoContent(HttpStatus httpStatus, String message) {
+        return new CommonResponse<>(httpStatus.value(), message);
     }
 
-    // 기본 에러 응답 생성 (에러 메시지만 포함, 코드 없음)
+    // 에러 응답 생성 (message만 포함)
     public static CommonResponse<?> createError(String message) {
-        return new CommonResponse<>(ERROR_STATUS, message, null);
+        return new CommonResponse<>(message);
     }
 
-    // 에러 코드와 메시지를 포함한 에러 응답 생성
-    public static CommonResponse<?> createError(String code, String message) {
-        Map<String, String> errorData = new HashMap<>();
-        errorData.put("code", code);
-        errorData.put("message", message);
-        return new CommonResponse<>(ERROR_STATUS, message, errorData);
+    // 에러 응답 생성 (status, code, message 포함)
+    public static CommonResponse<?> createError(HttpStatus httpStatus, String code, String message) {
+        return new CommonResponse<>(httpStatus.value(), code, message);
     }
 
-    // 유효성 검증 실패 응답 생성 (필드별 에러 메시지 포함)
+    // 유효성 검사 실패 시 필드별 에러 메시지 포함한 응답 생성
     public static CommonResponse<?> createValidationError(BindingResult bindingResult) {
         Map<String, String> fieldErrors = new HashMap<>();
         for (FieldError fieldError : bindingResult.getFieldErrors()) {
             fieldErrors.put(fieldError.getField(), fieldError.getDefaultMessage());
         }
-        return new CommonResponse<>(ERROR_STATUS, "요청 데이터가 유효하지 않습니다.", fieldErrors);
+        return new CommonResponse<>(HttpStatus.BAD_REQUEST.value(), "VALIDATION_FAILED", "요청 데이터가 유효하지 않습니다.", fieldErrors);
     }
 
-    // 생성자 - 내부에서만 사용, 공통 응답 구조 초기화
-    private CommonResponse(String status, String message, T data) {
+    // 생성자: 성공 응답용 (data 포함)
+    private CommonResponse(int status, String message, T data) {
         this.status = status;
         this.message = message;
         this.data = data;
+    }
+
+    // 생성자: 성공 응답용
+    private CommonResponse(int status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+
+    // 생성자: 에러 응답용 (code, message, data 포함)
+    private CommonResponse(int status, String code, String message, T data) {
+        this.status = status;
+        this.code = code;
+        this.message = message;
+        this.data = data;
+    }
+
+    // 생성자: 에러 응답용 (code, message만 포함)
+    private CommonResponse(int status, String code, String message) {
+        this.status = status;
+        this.code = code;
+        this.message = message;
+    }
+
+    // 생성자: 에러 응답용 (message만 포함)
+    private CommonResponse(String message) {
+        this.message = message;
     }
 }

--- a/cubco-domain/build.gradle
+++ b/cubco-domain/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa' // JPA
 
     runtimeOnly 'com.mysql:mysql-connector-j'
 

--- a/cubco-domain/src/main/java/org/cubco/coupon/domain/Coupon.java
+++ b/cubco-domain/src/main/java/org/cubco/coupon/domain/Coupon.java
@@ -7,6 +7,8 @@ import org.cubco.cafe.domain.Cafe;
 import org.cubco.common.BaseTimeEntity;
 import org.cubco.user.domain.User;
 
+import java.time.LocalTime;
+
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED) @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
@@ -41,5 +43,13 @@ public class Coupon extends BaseTimeEntity {
                 .count(count)
                 .imageUrl(imageUrl)
                 .build();
+    }
+
+    public void updateImage(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
+
+    public void updateCount(int count) {
+        this.count = count;
     }
 }

--- a/cubco-domain/src/main/java/org/cubco/policy/CouponOwnershipPolicy.java
+++ b/cubco-domain/src/main/java/org/cubco/policy/CouponOwnershipPolicy.java
@@ -1,15 +1,14 @@
 package org.cubco.policy;
 
 import org.cubco.coupon.domain.Coupon;
-import org.cubco.exception.CustomException;
-import org.cubco.exception.ErrorCode;
+import org.cubco.exception.CouponForbiddenException;
 import org.springframework.stereotype.Component;
 
 @Component
-public class CouponOwnershipPolicy implements CouponUsePolicy {
+public class CouponOwnershipPolicy {
     public void validateCouponOwner(Coupon coupon, Long userId) {
         if (!coupon.getUser().getId().equals(userId)) {
-            throw new CustomException(ErrorCode.FORBIDDEN); // 403 권한 없음
+            throw new CouponForbiddenException(); // 403 권한 없음
         }
     }
 }

--- a/cubco-domain/src/main/java/org/cubco/policy/CouponOwnershipPolicy.java
+++ b/cubco-domain/src/main/java/org/cubco/policy/CouponOwnershipPolicy.java
@@ -1,0 +1,15 @@
+package org.cubco.policy;
+
+import org.cubco.coupon.domain.Coupon;
+import org.cubco.exception.CustomException;
+import org.cubco.exception.ErrorCode;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CouponOwnershipPolicy implements CouponUsePolicy {
+    public void validateCouponOwner(Coupon coupon, Long userId) {
+        if (!coupon.getUser().getId().equals(userId)) {
+            throw new CustomException(ErrorCode.FORBIDDEN); // 403 권한 없음
+        }
+    }
+}

--- a/cubco-domain/src/main/java/org/cubco/policy/CouponRemainingCountPolicy.java
+++ b/cubco-domain/src/main/java/org/cubco/policy/CouponRemainingCountPolicy.java
@@ -1,0 +1,16 @@
+package org.cubco.policy;
+
+import org.cubco.coupon.domain.Coupon;
+import org.cubco.exception.CouponInsufficientCountException;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CouponRemainingCountPolicy implements CouponUsePolicy {
+
+    @Override
+    public void validateCouponCount(Coupon coupon, int count) {
+        if (coupon.getCount() < count) {
+            throw new CouponInsufficientCountException(); // 또는 CUSTOM_CODE
+        }
+    }
+}

--- a/cubco-domain/src/main/java/org/cubco/policy/CouponRemainingCountPolicy.java
+++ b/cubco-domain/src/main/java/org/cubco/policy/CouponRemainingCountPolicy.java
@@ -5,12 +5,10 @@ import org.cubco.exception.CouponInsufficientCountException;
 import org.springframework.stereotype.Component;
 
 @Component
-public class CouponRemainingCountPolicy implements CouponUsePolicy {
-
-    @Override
+public class CouponRemainingCountPolicy {
     public void validateCouponCount(Coupon coupon, int count) {
         if (coupon.getCount() < count) {
-            throw new CouponInsufficientCountException(); // 또는 CUSTOM_CODE
+            throw new CouponInsufficientCountException();
         }
     }
 }

--- a/cubco-domain/src/main/java/org/cubco/policy/CouponUsePolicy.java
+++ b/cubco-domain/src/main/java/org/cubco/policy/CouponUsePolicy.java
@@ -1,8 +1,8 @@
-package org.cubco.policy;
-
-import org.cubco.coupon.domain.Coupon;
-
-public interface CouponUsePolicy {
-    void validateCouponCount(Coupon coupon, int count);
-    void validateCouponOwner(Coupon coupon, Long userId);
-}
+//package org.cubco.policy;
+//
+//import org.cubco.coupon.domain.Coupon;
+//
+//public interface CouponUsePolicy {
+//    void validateCouponCount(Coupon coupon, int count);
+//    void validateCouponOwner(Coupon coupon, Long userId);
+//}

--- a/cubco-domain/src/main/java/org/cubco/policy/CouponUsePolicy.java
+++ b/cubco-domain/src/main/java/org/cubco/policy/CouponUsePolicy.java
@@ -1,0 +1,8 @@
+package org.cubco.policy;
+
+import org.cubco.coupon.domain.Coupon;
+
+public interface CouponUsePolicy {
+    void validateCouponCount(Coupon coupon, int count);
+    void validateCouponOwner(Coupon coupon, Long userId);
+}

--- a/cubco-domain/src/main/java/org/cubco/repository/CouponRepository.java
+++ b/cubco-domain/src/main/java/org/cubco/repository/CouponRepository.java
@@ -1,0 +1,18 @@
+package org.cubco.repository;
+
+import org.cubco.coupon.domain.Coupon;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface CouponRepository extends JpaRepository<Coupon, Long> {
+
+    @Query("SELECT c FROM Coupon c JOIN FETCH c.user WHERE c.user.id = :userId")
+    List<Coupon> findAllByUserId(@Param("userId") Long userId);
+
+    Optional<Coupon> findByUserIdAndId(Long userId, Long couponId);
+}
+


### PR DESCRIPTION
## 🔥*Pull requests*

#️⃣️ **작업한 브랜치**
- feat/#19

📄  **작업한 내용**
<!-- 작업에 대한 간략한 설명 -->
###  쿠폰 관련 API
- **사용자 보유 쿠폰 리스트 조회**
  - userId 기반 쿠폰 리스트 조회
  
- **쿠폰 상세 조회**
  - userId 기반 쿠폰 상세 조회
  
- **쿠폰 이미지 변경**
  - JWT 토큰의 userId와 쿠폰의 userId를 비교 후 수정권한이 있는지 확인 -> 차후에 User 쪽 구현되면 User의 role을 비교하는 방식으로 수정하도록 하겠습니다.
  - imageURL 유효성검사
  
- **쿠폰 사용**
  - JWT 토큰의 userId와 쿠폰의 userId를 비교 후 수정권한이 있는지 확인 -> 차후에 User 쪽 구현되면 User의 role을 비교하는 방식으로 수정하도록 하겠습니다.
  - count(도장 수) 유효성검사
  
- **API 관련 DTO 생성**

- `CouponForbiddenException`, `CouponInsufficientCountException`, `CouponNotFoundException` 예외처리 클래스 생성

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- `userId` 는 PR 후 @UserId 어노테이션을 달아서 사용하도록 하겠습니다.
- Cafe 쪽 구현완료 되면 Response에 카페 정보도 담도록 하겠습니다.

## 💻 관련 이슈
- Resolved: #19 

## 💬 리뷰 요구사항 (선택)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->
- 피드백 있으시면 편하게 주세요!