### PR TITLE
[FEAT] 큐레이션 관련 API 구현 (#14)

### DIFF
--- a/cubco-api/src/main/java/org/cubco/auth/config/SecurityConfig.java
+++ b/cubco-api/src/main/java/org/cubco/auth/config/SecurityConfig.java
@@ -3,12 +3,11 @@ package org.cubco.auth.config;
 import io.jsonwebtoken.Jwts;
 import org.cubco.auth.filter.JwtAuthenticationFilter;
 import org.cubco.auth.handler.CustomAccessDeniedHandler;
-import org.cubco.auth.jwt.JWTutil;
+import org.cubco.auth.jwt.JWTUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.PropertySource;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -21,11 +20,8 @@ import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
 
 @Configuration
-@PropertySource("classpath:security.properties")
 public class SecurityConfig {
-
     private final CustomAccessDeniedHandler accessDeniedHandler;
-
 
     @Autowired
     public SecurityConfig(CustomAccessDeniedHandler accessDeniedHandler) {
@@ -46,7 +42,7 @@ public class SecurityConfig {
     }
 
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http, JWTutil jwTutil) throws Exception {
+    public SecurityFilterChain securityFilterChain(HttpSecurity http, JWTUtil jwTutil) throws Exception {
         http
                 .exceptionHandling(exception -> exception
                         .accessDeniedHandler(accessDeniedHandler)); //인가 예외처리

--- a/cubco-api/src/main/java/org/cubco/auth/filter/JwtAuthenticationFilter.java
+++ b/cubco-api/src/main/java/org/cubco/auth/filter/JwtAuthenticationFilter.java
@@ -8,7 +8,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.cubco.exception.ErrorCode;
 import org.cubco.response.CommonResponse;
-import org.cubco.auth.jwt.JWTutil;
+import org.cubco.auth.jwt.JWTUtil;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -25,11 +25,10 @@ import java.util.List;
 @Slf4j
 @Component
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private final JWTUtil jwtUtil;
 
-    private JWTutil jwTutil;
-
-    public JwtAuthenticationFilter(JWTutil jwTutil) {
-        this.jwTutil = jwTutil;
+    public JwtAuthenticationFilter(JWTUtil jwTutil) {
+        this.jwtUtil = jwTutil;
     }
 
 
@@ -44,17 +43,17 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         try {
-            String token = jwTutil.extractToken(request);
+            String token = jwtUtil.extractToken(request);
 
             if (token == null) {
                 filterChain.doFilter(request, response);
                 return;
             }
 
-            String userId = jwTutil.getUserId(token);
-            String role = jwTutil.getRole(token);
+            String userId = jwtUtil.getUserId(token);
+            String role = jwtUtil.getRole(token);
 
-            if (jwTutil.isExpired(token)) {
+            if (jwtUtil.isExpired(token)) {
                 CommonResponse<?> errorResponse = CommonResponse.createError("유효기간이 만료된 토큰입니다.");
                 handleAuthenticationError(response, errorResponse);
                 return;

--- a/cubco-api/src/main/java/org/cubco/auth/jwt/JWTUtil.java
+++ b/cubco-api/src/main/java/org/cubco/auth/jwt/JWTUtil.java
@@ -4,21 +4,19 @@ import io.jsonwebtoken.Jwts;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.PropertySource;
 import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
 import java.util.Date;
 
 @Component
-@PropertySource("classpath:security.properties")
-public class JWTutil {
+public class JWTUtil {
 
     private final SecretKey secretKey;
     private final int expiredms;
 
     @Autowired
-    public JWTutil(SecretKey secretKey, @Value("${jwt.expiration}")int expiredms){
+    public JWTUtil(SecretKey secretKey, @Value("${jwt.expiration}")int expiredms){
         this.expiredms = expiredms;
         this.secretKey = secretKey;
     }
@@ -53,7 +51,6 @@ public class JWTutil {
         }
     }
 
-
     public String createToken(Long userId, String role){
         return Jwts.builder()
                 .setSubject(String.valueOf(userId))
@@ -63,5 +60,4 @@ public class JWTutil {
                 .signWith(secretKey)
                 .compact();
     }
-
 }

--- a/cubco-api/src/main/java/org/cubco/auth/resolver/AuthenticationPrincipalArgumentResolver.java
+++ b/cubco-api/src/main/java/org/cubco/auth/resolver/AuthenticationPrincipalArgumentResolver.java
@@ -2,6 +2,7 @@ package org.cubco.auth.resolver;
 
 import org.springframework.core.MethodParameter;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
@@ -19,8 +20,7 @@ public class AuthenticationPrincipalArgumentResolver implements HandlerMethodArg
 
     @Override
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
-        return SecurityContextHolder.getContext()
-                .getAuthentication()
-                .getPrincipal();
+        User user = (User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        return Long.valueOf(user.getUsername());
     }
 }

--- a/cubco-api/src/main/java/org/cubco/config/AsyncConfig.java
+++ b/cubco-api/src/main/java/org/cubco/config/AsyncConfig.java
@@ -1,0 +1,9 @@
+package org.cubco.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+}

--- a/cubco-api/src/main/java/org/cubco/config/SwaggerConfig.java
+++ b/cubco-api/src/main/java/org/cubco/config/SwaggerConfig.java
@@ -1,11 +1,25 @@
 package org.cubco.config;
 
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 
+import java.util.ArrayList;
+
+@SecurityScheme(
+        name = "Authorization",
+        type = SecuritySchemeType.HTTP,
+        in = SecuritySchemeIn.HEADER,
+        bearerFormat = "JWT",
+        scheme = "Bearer"
+)
 @Configuration
 public class SwaggerConfig {
     @Bean
@@ -20,5 +34,13 @@ public class SwaggerConfig {
                 .title("CubCo Swagger")
                 .description("CubCo Backend REST API")
                 .version("1.0.0");
+    }
+
+    public SwaggerConfig(MappingJackson2HttpMessageConverter converter) {
+        var supportedMediaTypes = new ArrayList<>(converter.getSupportedMediaTypes());
+        supportedMediaTypes.add(new MediaType("application", "json"));
+        supportedMediaTypes.add(new MediaType("multipart", "form-data"));
+        supportedMediaTypes.add(new MediaType("application", "octet-stream"));
+        converter.setSupportedMediaTypes(supportedMediaTypes);
     }
 }

--- a/cubco-api/src/main/java/org/cubco/curation/api/CurationApi.java
+++ b/cubco-api/src/main/java/org/cubco/curation/api/CurationApi.java
@@ -1,0 +1,122 @@
+package org.cubco.curation.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.cubco.auth.resolver.UserId;
+import org.cubco.curation.dto.request.CurationCreateReq;
+import org.cubco.curation.dto.response.CurationCreateRes;
+import org.cubco.curation.dto.response.CurationGetDetailRes;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Tag(name = "큐레이션 관련 API")
+@SecurityRequirement(name = "Authorization")
+public interface CurationApi {
+    @Operation(
+            summary = "큐레이션 생성 API",
+            responses = {
+                    @ApiResponse(responseCode = "201",
+                            content = @Content(
+                                    schema = @Schema(implementation = CurationCreateRes.class),
+                                    examples = @ExampleObject(value = """
+                                            {
+                                                "curationId": 1
+                                            }
+                                            """)
+                            ), description = "큐레이션 등록에 성공하였습니다."),
+                    @ApiResponse(responseCode = "400", description = "잘못된 요청입니다.", content = @Content),
+                    @ApiResponse(responseCode = "401", description = "액세스 토큰의 형식이 올바르지 않습니다. Bearer 타입을 확인해 주세요.", content = @Content),
+                    @ApiResponse(responseCode = "401", description = "액세스 토큰의 값이 올바르지 않습니다.", content = @Content),
+                    @ApiResponse(responseCode = "401", description = "액세스 토큰이 만료되었습니다. 재발급 받아주세요.", content = @Content),
+                    @ApiResponse(responseCode = "405", description = "잘못된 HTTP method 요청입니다.", content = @Content),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류입니다.", content = @Content)
+            }
+    )
+    ResponseEntity<CurationCreateRes> createCuration(@Parameter(hidden = true) @UserId Long userId,
+                                                     @Parameter(description = "큐레이션 제목 및 내용") @RequestPart("curation") CurationCreateReq curation,
+                                                     @Parameter(description = "큐레이션 이미지") @RequestPart("images") List<MultipartFile> images);
+
+    @Operation(
+            summary = "큐레이션 정보 조회 API",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "큐레이션 상세 정보 조회에 성공했습니다.",
+                            content = @Content(
+                                    schema = @Schema(implementation = CurationGetDetailRes.class),
+                                    examples = @ExampleObject(value = """
+                                            {
+                                              "curationId": 123,
+                                              "images": [
+                                                {
+                                                  "imageUrl": "https://example.com/curation/image1.jpg",
+                                                  "sortOrder": 1
+                                                },
+                                                {
+                                                  "imageUrl": "https://example.com/curation/image2.jpg",
+                                                  "sortOrder": 2
+                                                }
+                                              ],
+                                              "tags": [
+                                                {
+                                                  "name": "데이트하기 좋은"
+                                                },
+                                                {
+                                                  "name": "분위기 좋은"
+                                                }
+                                              ],
+                                              "title": "서울 분위기 맛집 카페 추천",
+                                              "content": "연인들과 즐기기 좋은 분위기 맛집 카페를 소개합니다.",
+                                              "reportCount": 1,
+                                              "likeCount": 57,
+                                              "isUserLiked": true
+                                            }
+                                            """)
+                            )
+                    ),
+                    @ApiResponse(responseCode = "400", description = "잘못된 요청입니다.", content = @Content),
+                    @ApiResponse(responseCode = "401", description = "액세스 토큰의 형식이 올바르지 않습니다. Bearer 타입을 확인해 주세요.", content = @Content),
+                    @ApiResponse(responseCode = "401", description = "액세스 토큰의 값이 올바르지 않습니다.", content = @Content),
+                    @ApiResponse(responseCode = "401", description = "액세스 토큰이 만료되었습니다. 재발급 받아주세요.", content = @Content),
+                    @ApiResponse(responseCode = "405", description = "잘못된 HTTP method 요청입니다.", content = @Content),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류입니다.", content = @Content)})
+    ResponseEntity<CurationGetDetailRes> getCurationDetail(
+            @Parameter(hidden = true) @UserId Long userId,
+            @PathVariable("curationId") Long curationId);
+
+    @Operation(
+            summary = "큐레이션 좋아요 등록 API",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "큐레이션에 좋아요가 등록되었습니다.", content = @Content),
+                    @ApiResponse(responseCode = "400", description = "잘못된 요청입니다.", content = @Content),
+                    @ApiResponse(responseCode = "401", description = "액세스 토큰의 형식이 올바르지 않습니다. Bearer 타입을 확인해 주세요.", content = @Content),
+                    @ApiResponse(responseCode = "401", description = "액세스 토큰의 값이 올바르지 않습니다.", content = @Content),
+                    @ApiResponse(responseCode = "401", description = "액세스 토큰이 만료되었습니다. 재발급 받아주세요.", content = @Content),
+                    @ApiResponse(responseCode = "405", description = "잘못된 HTTP method 요청입니다.", content = @Content),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류입니다.", content = @Content)})
+    ResponseEntity<Void> createCurationLike(@Parameter(hidden = true) @UserId Long userId,
+                                            @PathVariable("curationId") Long curationId);
+
+    @Operation(
+            summary = "큐레이션 좋아요 해제 API",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "큐레이션에 좋아요가 해제되었습니다.", content = @Content),
+                    @ApiResponse(responseCode = "400", description = "잘못된 요청입니다.", content = @Content),
+                    @ApiResponse(responseCode = "401", description = "액세스 토큰의 형식이 올바르지 않습니다. Bearer 타입을 확인해 주세요.", content = @Content),
+                    @ApiResponse(responseCode = "401", description = "액세스 토큰의 값이 올바르지 않습니다.", content = @Content),
+                    @ApiResponse(responseCode = "401", description = "액세스 토큰이 만료되었습니다. 재발급 받아주세요.", content = @Content),
+                    @ApiResponse(responseCode = "405", description = "잘못된 HTTP method 요청입니다.", content = @Content),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류입니다.", content = @Content)})
+    ResponseEntity<Void> deleteCurationLike(@Parameter(hidden = true) @UserId Long userId,
+                                            @PathVariable("curationId") Long curationId);
+}

--- a/cubco-api/src/main/java/org/cubco/curation/api/CurationController.java
+++ b/cubco-api/src/main/java/org/cubco/curation/api/CurationController.java
@@ -1,0 +1,50 @@
+package org.cubco.curation.api;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.cubco.auth.resolver.UserId;
+import org.cubco.curation.dto.request.CurationCreateReq;
+import org.cubco.curation.dto.response.CurationCreateRes;
+import org.cubco.curation.dto.response.CurationGetDetailRes;
+import org.cubco.curation.service.CurationService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/curations")
+@RequiredArgsConstructor
+public class CurationController implements CurationApi {
+    private final CurationService curationService;
+
+    @PostMapping(consumes = {MediaType.MULTIPART_FORM_DATA_VALUE, MediaType.APPLICATION_JSON_VALUE},
+            produces = {MediaType.MULTIPART_FORM_DATA_VALUE, MediaType.APPLICATION_JSON_VALUE})
+    public ResponseEntity<CurationCreateRes> createCuration(@UserId Long userId,
+                                                            @RequestPart("curation") @Valid CurationCreateReq curation,
+                                                            @RequestPart("images") List<MultipartFile> images) {
+        CurationCreateRes dateCreateRes = curationService.createCuration(userId, curation, images);
+        return ResponseEntity.status(HttpStatus.CREATED).body(dateCreateRes);
+    }
+
+    @PostMapping("/{curationId}/likes")
+    public ResponseEntity<Void> createCurationLike(@UserId Long userId, @PathVariable("curationId") Long curationId) {
+        curationService.createCurationLike(userId, curationId);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/{curationId}/likes")
+    public ResponseEntity<Void> deleteCurationLike(@UserId Long userId, @PathVariable("curationId") Long curationId) {
+        curationService.deleteCurationLike(userId, curationId);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/{curationId}")
+    public ResponseEntity<CurationGetDetailRes> getCurationDetail(@UserId Long userId, @PathVariable("curationId") Long curationId) {
+        CurationGetDetailRes curationGetDetailRes = curationService.getCurationDetail(userId, curationId);
+        return ResponseEntity.status(HttpStatus.OK).body(curationGetDetailRes);
+    }
+}

--- a/cubco-api/src/main/java/org/cubco/curation/dto/request/CurationCreateReq.java
+++ b/cubco-api/src/main/java/org/cubco/curation/dto/request/CurationCreateReq.java
@@ -1,0 +1,20 @@
+package org.cubco.curation.dto.request;
+
+import jakarta.validation.constraints.Size;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED) @AllArgsConstructor
+public class CurationCreateReq {
+    @Size(min = 5)
+    String title;
+
+    @Size(min = 10)
+    String content;
+
+    @Size(min = 1, max = 5)
+    List<TagCreateReq> tags;
+}

--- a/cubco-api/src/main/java/org/cubco/curation/dto/request/CurationCreateSwaggerDto.java
+++ b/cubco-api/src/main/java/org/cubco/curation/dto/request/CurationCreateSwaggerDto.java
@@ -1,0 +1,10 @@
+package org.cubco.curation.dto.request;
+
+import java.util.List;
+import org.springframework.web.multipart.MultipartFile;
+
+public record CurationCreateSwaggerDto(
+        CurationCreateReq curation,
+        List<TagCreateReq> tags,
+        List<MultipartFile> images
+) {}

--- a/cubco-api/src/main/java/org/cubco/curation/dto/request/TagCreateReq.java
+++ b/cubco-api/src/main/java/org/cubco/curation/dto/request/TagCreateReq.java
@@ -1,0 +1,12 @@
+package org.cubco.curation.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+@Getter @Setter
+@Builder(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED) @AllArgsConstructor
+public class TagCreateReq {
+    @Schema(description = "큐레이션 태그", example = "데이트")
+    private String name;
+}

--- a/cubco-api/src/main/java/org/cubco/curation/dto/response/CurationCreateRes.java
+++ b/cubco-api/src/main/java/org/cubco/curation/dto/response/CurationCreateRes.java
@@ -1,0 +1,15 @@
+package org.cubco.curation.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+
+@Builder(access = AccessLevel.PROTECTED)
+public record CurationCreateRes(
+        Long curationId
+) {
+    public static CurationCreateRes of(Long curationId) {
+        return CurationCreateRes.builder()
+                .curationId(curationId)
+                .build();
+    }
+}

--- a/cubco-api/src/main/java/org/cubco/curation/dto/response/CurationGetDetailRes.java
+++ b/cubco-api/src/main/java/org/cubco/curation/dto/response/CurationGetDetailRes.java
@@ -1,0 +1,60 @@
+package org.cubco.curation.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import org.cubco.curation.domain.Curation;
+
+import java.util.List;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record CurationGetDetailRes(
+        Long curationId,
+        List<ImageList> images,
+        List<CurationTag> tags,
+        String title,
+        String content,
+        int reportCount,
+        int likeCount,
+        boolean isUserLiked
+) {
+    public static CurationGetDetailRes of(Curation curation,
+                                          List<ImageList> images,
+                                          List<CurationTag> tags,
+                                          int likeCount,
+                                          boolean isUserLiked) {
+        return CurationGetDetailRes.builder()
+                .curationId(curation.getId())
+                .images(images)
+                .tags(tags)
+                .title(curation.getTitle())
+                .content(curation.getContent())
+                .reportCount(curation.getReportCount())
+                .likeCount(likeCount)
+                .isUserLiked(isUserLiked)
+                .build();
+    }
+
+    @Builder(access = AccessLevel.PRIVATE)
+    public record ImageList(
+            String imageUrl,
+            int sortOrder
+    ) {
+        public static ImageList of(String imageUrl, int sortOrder) {
+            return ImageList.builder()
+                    .imageUrl(imageUrl)
+                    .sortOrder(sortOrder)
+                    .build();
+        }
+    }
+
+    @Builder(access = AccessLevel.PRIVATE)
+    public record CurationTag(
+            String name
+    ) {
+        public static CurationTag of(String name) {
+            return CurationTag.builder()
+                    .name(name)
+                    .build();
+        }
+    }
+}

--- a/cubco-api/src/main/java/org/cubco/curation/service/AsyncService.java
+++ b/cubco-api/src/main/java/org/cubco/curation/service/AsyncService.java
@@ -1,0 +1,39 @@
+package org.cubco.curation.service;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.cubco.curation.domain.Curation;
+import org.cubco.exception.EntityNotFoundException;
+import org.cubco.exception.ErrorCode;
+import org.cubco.image.service.ImageService;
+import org.cubco.curation.dto.request.TagCreateReq;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+@Transactional(readOnly = true)
+public class AsyncService {
+    private final ImageService imageService;
+    private final CurationTagService curationTagService;
+
+    @Transactional
+    public void createCurationImage(List<MultipartFile> images, Curation curation) {
+        if (images.isEmpty()) {
+            throw new EntityNotFoundException(ErrorCode.IMAGE_NOT_FOUND);
+        }
+        imageService.saveCurationImages(images, curation);
+    }
+
+    @Async
+    public void createCurationTags(List<TagCreateReq> tags, Curation curation) {
+        if (tags.isEmpty()) {
+            throw new EntityNotFoundException(ErrorCode.TAG_NOT_FOUND);
+        }
+        curationTagService.createCurationTag(tags, curation);
+    }
+}

--- a/cubco-api/src/main/java/org/cubco/curation/service/CurationService.java
+++ b/cubco-api/src/main/java/org/cubco/curation/service/CurationService.java
@@ -1,0 +1,141 @@
+package org.cubco.curation.service;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.cubco.curation.domain.Curation;
+import org.cubco.curation.dto.request.CurationCreateReq;
+import org.cubco.curation.dto.response.CurationCreateRes;
+import org.cubco.curation.dto.response.CurationGetDetailRes;
+import org.cubco.curation.repository.CurationRepository;
+import org.cubco.exception.EntityNotFoundException;
+import org.cubco.exception.ErrorCode;
+import org.cubco.image.domain.CurationImage;
+import org.cubco.image.repository.CurationImageRepository;
+import org.cubco.like.domain.Like;
+import org.cubco.like.repository.LikeRepository;
+import org.cubco.tag.domain.CurationTag;
+import org.cubco.tag.repository.CurationTagRepository;
+import org.cubco.user.domain.User;
+import org.cubco.user.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+@Transactional(readOnly = true)
+public class CurationService {
+    private final CurationRepository curationRepository;
+    private final CurationImageRepository curationImageRepository;
+    private final CurationTagRepository curationTagRepository;
+    private final UserRepository userRepository;
+    private final LikeRepository likeRepository;
+    private final AsyncService asyncService;
+
+    @Transactional
+    public CurationCreateRes createCuration(Long userId, CurationCreateReq curationCreateReq, List<MultipartFile> images) {
+        User user = getUser(userId);
+        Curation curation = Curation.create(user, curationCreateReq.getTitle(), curationCreateReq.getContent());
+        Curation saveCuration = curationRepository.save(curation);
+        asyncService.createCurationImage(images, saveCuration);
+        asyncService.createCurationTags(curationCreateReq.getTags(), saveCuration);
+        return CurationCreateRes.of(saveCuration.getId());
+    }
+
+    @Transactional
+    public void createCurationLike(Long userId, Long curationId) {
+        User user = getUser(userId);
+        Curation curation = getCuration(curationId);
+        saveCurationLike(user, curation);
+    }
+
+    @Transactional
+    public void deleteCurationLike(Long userId, Long curationId) {
+        User user = getUser(userId);
+        Curation curation = getCuration(curationId);
+        deleteCurationLike(user, curation);
+    }
+
+    public CurationGetDetailRes getCurationDetail(Long userId, Long curationId) {
+        User user = getUser(userId);
+        Curation curation = getCuration(curationId);
+        List<CurationImage> images = getCurationImages(curation);
+        validateImage(images);
+
+        List<CurationGetDetailRes.ImageList> imagesRes = images.stream().map(
+                imageList -> CurationGetDetailRes.ImageList.of(
+                        imageList.getImageUrl(),
+                        imageList.getSortOrder()
+                )).toList();
+
+        List<CurationTag> tags = getCurationTags(curation);
+        validateCurationTag(tags);
+        List<CurationGetDetailRes.CurationTag> tagsRes = tags.stream().map(
+                tagList -> CurationGetDetailRes.CurationTag.of(
+                        tagList.getName()
+                )).toList();
+
+        int likeCount = getLikeCount(curation);
+        boolean isMyCuration = isAuthor(user, curation.getId());
+        boolean isUserLiked = false;
+        if (!isMyCuration) {
+            isUserLiked = hasUserLikedCuration(user, curation);
+        }
+
+        return CurationGetDetailRes.of(curation, imagesRes, tagsRes, likeCount, isUserLiked);
+    }
+
+    private User getUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    private Curation getCuration(Long curationId) {
+        return curationRepository.findById(curationId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.CURATION_NOT_FOUND));
+    }
+
+    private List<CurationImage> getCurationImages(Curation curation) {
+        return curationImageRepository.findAllByCuration(curation);
+    }
+
+    private void validateImage(List<CurationImage> images) {
+        if (images.isEmpty()) {
+            throw new EntityNotFoundException(ErrorCode.IMAGE_NOT_FOUND);
+        }
+    }
+
+    private List<CurationTag> getCurationTags(Curation curation) {
+        return curationTagRepository.findAllByCuration(curation);
+    }
+
+    private void validateCurationTag(List<CurationTag> curationTags) {
+        if (curationTags.isEmpty()) {
+            throw new EntityNotFoundException(ErrorCode.TAG_NOT_FOUND);
+        }
+    }
+
+    private int getLikeCount(Curation curation) {
+        return likeRepository.countByCuration(curation);
+    }
+
+    private boolean isAuthor(User user, Long curationId) {
+        return curationRepository.existsByUserAndId(user, curationId);
+    }
+
+    private boolean hasUserLikedCuration(User user, Curation curation) {
+        return likeRepository.existsLikeByUserAndCuration(user, curation);
+    }
+
+    private void deleteCurationLike(User user, Curation curation) {
+        Like like = likeRepository.findLikeByUserAndCuration(user, curation);
+        likeRepository.delete(like);
+    }
+
+    private void saveCurationLike(User user, Curation curation) {
+        Like like = Like.create(user, curation);
+        likeRepository.save(like);
+    }
+}

--- a/cubco-api/src/main/java/org/cubco/curation/service/CurationTagService.java
+++ b/cubco-api/src/main/java/org/cubco/curation/service/CurationTagService.java
@@ -1,0 +1,26 @@
+package org.cubco.curation.service;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.cubco.curation.domain.Curation;
+import org.cubco.tag.domain.CurationTag;
+import org.cubco.curation.dto.request.TagCreateReq;
+import org.cubco.tag.repository.CurationTagRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class CurationTagService {
+    private final CurationTagRepository curationTagRepository;
+
+    @Transactional
+    public void createCurationTag(List<TagCreateReq> tags, Curation curation) {
+        List<CurationTag> curationTags = tags.stream()
+                .map(tag -> CurationTag.create(curation, tag.getName()))
+                .toList();
+        curationTagRepository.saveAll(curationTags);
+    }
+}

--- a/cubco-api/src/main/java/org/cubco/image/service/ImageService.java
+++ b/cubco-api/src/main/java/org/cubco/image/service/ImageService.java
@@ -1,0 +1,41 @@
+package org.cubco.image.service;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.cubco.curation.domain.Curation;
+import org.cubco.exception.BadRequestException;
+import org.cubco.exception.ErrorCode;
+import org.cubco.image.domain.CurationImage;
+import org.cubco.image.repository.CurationImageRepository;
+import org.cubco.s3.S3Service;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+@Transactional(readOnly = true)
+public class ImageService {
+    private final CurationImageRepository curationImageRepository;
+    private final S3Service s3Service;
+
+    @Transactional
+    public void saveCurationImages(List<MultipartFile> images, Curation curation) {
+        AtomicInteger sequence = new AtomicInteger();
+        Long curationId = curation.getId();
+        List<CurationImage> curationImages = images.stream().map(image -> {
+            try {
+                return CurationImage.create(curation, s3Service.uploadImage("curation/", image, curationId), sequence.getAndIncrement());
+            } catch (IOException e) {
+                throw new BadRequestException(ErrorCode.INVALID_REQUEST);
+            }
+        }).toList();
+        curationImageRepository.saveAll(curationImages);
+    }
+}

--- a/cubco-api/src/main/java/org/cubco/user/api/UserController.java
+++ b/cubco-api/src/main/java/org/cubco/user/api/UserController.java
@@ -1,0 +1,22 @@
+package org.cubco.user.api;
+
+import lombok.RequiredArgsConstructor;
+import org.cubco.user.dto.response.UserJwtRes;
+import org.cubco.user.service.AuthService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/users")
+public class UserController {
+    private final AuthService authService;
+
+    @PostMapping("/test")
+    public ResponseEntity<UserJwtRes> testLogin() {
+        UserJwtRes userJwtRes = authService.testLogin();
+        return ResponseEntity.ok(userJwtRes);
+    }
+}

--- a/cubco-api/src/main/java/org/cubco/user/dto/response/UserJwtRes.java
+++ b/cubco-api/src/main/java/org/cubco/user/dto/response/UserJwtRes.java
@@ -1,0 +1,17 @@
+package org.cubco.user.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record UserJwtRes(
+        Long userId,
+        String accessToken
+) {
+    public static UserJwtRes of(Long userId, String accessToken) {
+        return UserJwtRes.builder()
+                .userId(userId)
+                .accessToken(accessToken)
+                .build();
+    }
+}

--- a/cubco-api/src/main/java/org/cubco/user/service/AuthService.java
+++ b/cubco-api/src/main/java/org/cubco/user/service/AuthService.java
@@ -1,0 +1,27 @@
+package org.cubco.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.cubco.auth.jwt.JWTUtil;
+import org.cubco.user.domain.RoleType;
+import org.cubco.user.domain.SocialType;
+import org.cubco.user.domain.Status;
+import org.cubco.user.domain.User;
+import org.cubco.user.dto.response.UserJwtRes;
+import org.cubco.user.repository.UserRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+    private final JWTUtil jwtutil;
+    private final UserRepository userRepository;
+
+    public UserJwtRes testLogin() {
+        User user = User.create("test", "test@test.com", "010-1234-5678", "서울 성북구", SocialType.TEST, "1", Status.ACTIVE, RoleType.MEMBER);
+        if (userRepository.findByEmail(user.getEmail()).isEmpty()) {
+            userRepository.save(user);
+        }
+        String token = jwtutil.createToken(user.getId(), user.getRoleType().name());
+        return UserJwtRes.of(user.getId(), token);
+    }
+}

--- a/cubco-api/src/main/resources/security.properties
+++ b/cubco-api/src/main/resources/security.properties
@@ -1,2 +1,0 @@
-jwt.secret=jXn2r5u8x/A?D(G+KbPeShVmYp3s6v9y
-jwt.expiration=86400000

--- a/cubco-common/src/main/java/org/cubco/exception/BadRequestException.java
+++ b/cubco-common/src/main/java/org/cubco/exception/BadRequestException.java
@@ -1,0 +1,10 @@
+package org.cubco.exception;
+
+public class BadRequestException extends CustomException {
+    public BadRequestException() {
+        super(ErrorCode.INVALID_REQUEST);
+    }
+    public BadRequestException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/cubco-common/src/main/java/org/cubco/exception/EntityNotFoundException.java
+++ b/cubco-common/src/main/java/org/cubco/exception/EntityNotFoundException.java
@@ -1,0 +1,11 @@
+package org.cubco.exception;
+
+
+public class EntityNotFoundException extends CustomException {
+    public EntityNotFoundException() {
+        super(ErrorCode.ENTITY_NOT_FOUND);
+    }
+    public EntityNotFoundException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/cubco-common/src/main/java/org/cubco/exception/ErrorCode.java
+++ b/cubco-common/src/main/java/org/cubco/exception/ErrorCode.java
@@ -6,10 +6,15 @@ public enum ErrorCode {
 
     // 400 Bad Request
     INVALID_REQUEST(HttpStatus.BAD_REQUEST, "INVALID_REQUEST", "요청이 올바르지 않습니다."),
-//    DUPLICATED_EMAIL(HttpStatus.BAD_REQUEST, "DUPLICATED_EMAIL", "이미 등록된 이메일입니다."),
+    //    DUPLICATED_EMAIL(HttpStatus.BAD_REQUEST, "DUPLICATED_EMAIL", "이미 등록된 이메일입니다."),
     MISSING_REQUIRED_FIELD(HttpStatus.BAD_REQUEST, "MISSING_REQUIRED_FIELD", "필수 입력값이 누락되었습니다."),
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "INVALID_INPUT_VALUE", "입력값이 유효하지 않습니다."),
     VALIDATION_FAILED(HttpStatus.BAD_REQUEST, "VALIDATION_FAILED", "요청 데이터가 유효하지 않습니다."),
+    INVALID_FILE_EXTENSION(HttpStatus.BAD_REQUEST, "INVALID_FILE_EXTENSION", "지원하지 않는 확장자입니다."),
+    INVALID_FILE_SIZE(HttpStatus.BAD_REQUEST, "INVALID_FILE_SIZE", "파일 크기가 너무 큽니다."),
+    INVALID_FILE_EMPTY(HttpStatus.BAD_REQUEST, "INVALID_FILE_EMPTY", "파일이 비어 있습니다."),
+    INVALID_IMAGE_URL(HttpStatus.BAD_REQUEST, "INVALID_IMAGE_URL", "잘못된 이미지 URL 입니다."),
+    FAIL_DELETE_IMAGE(HttpStatus.BAD_REQUEST, "FAIL_DELETE_IMAGE", "파일 삭제에 실패하였습니다."),
 
     // 401 Unauthorized
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED", "인증이 필요합니다."),
@@ -24,6 +29,12 @@ public enum ErrorCode {
     NOT_FOUND(HttpStatus.NOT_FOUND, "NOT_FOUND", "요청한 자원이 존재하지 않습니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_NOT_FOUND", "해당 사용자를 찾을 수 없습니다."),
     COUPON_NOT_FOUND(HttpStatus.NOT_FOUND, "COUPON_NOT_FOUND", "존재하는 쿠폰을 찾을 수 없습니다."),
+    ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND, "ENTITY_NOT_FOUND", "대상을 찾을 수 없습니다."),
+    IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "IMAGE_NOT_FOUND", "해당 이미지가 존재하지 않습니다"),
+    CURATION_NOT_FOUND(HttpStatus.NOT_FOUND, "CURATION_NOT_FOUND", "큐레이션이 존재하지 않습니다"),
+    TAG_NOT_FOUND(HttpStatus.NOT_FOUND, "TAG_NOT_FOUND", "태그가 존재하지 않습니다"),
+    LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "LIKE_NOT_FOUND", "좋아요 내역이 존재하지 않습니다"),
+//    MENU_NOT_FOUND(HttpStatus.NOT_FOUND, "MENU_NOT_FOUND", "해당 메뉴를 찾을 수 없습니다."),
 //    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST_NOT_FOUND", "해당 게시글을 찾을 수 없습니다."),
 
     // 405 Method Not Allowed
@@ -31,7 +42,8 @@ public enum ErrorCode {
 
     // 500 Internal Server Error
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR", "서버 내부 오류가 발생했습니다."),
-    UNKNOWN_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "UNKNOWN_ERROR", "예기치 못한 오류가 발생했습니다.");
+    UNKNOWN_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "UNKNOWN_ERROR", "예기치 못한 오류가 발생했습니다."),
+    FILE_UPLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "FILE_UPLOAD_FAIL", "파일 업로드에 실패했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/cubco-common/src/main/java/org/cubco/exception/InvalidValueException.java
+++ b/cubco-common/src/main/java/org/cubco/exception/InvalidValueException.java
@@ -1,0 +1,11 @@
+package org.cubco.exception;
+
+public class InvalidValueException extends CustomException {
+    public InvalidValueException() {
+        super(ErrorCode.INVALID_REQUEST);
+    }
+
+    public InvalidValueException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/cubco-domain/src/main/java/org/cubco/curation/domain/Curation.java
+++ b/cubco-domain/src/main/java/org/cubco/curation/domain/Curation.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import org.cubco.common.BaseTimeEntity;
+import org.cubco.user.domain.User;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED) @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -29,11 +30,15 @@ public class Curation extends BaseTimeEntity {
     @Column(name = "report_count")
     private int reportCount = 0;
 
-    public static Curation create(String title, String content, int reportCount) {
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    public static Curation create(User user, String title, String content) {
         return Curation.builder()
+                .user(user)
                 .title(title)
                 .content(content)
-                .reportCount(reportCount)
                 .build();
     }
 }

--- a/cubco-domain/src/main/java/org/cubco/curation/repository/CurationRepository.java
+++ b/cubco-domain/src/main/java/org/cubco/curation/repository/CurationRepository.java
@@ -1,0 +1,11 @@
+package org.cubco.curation.repository;
+
+import org.cubco.curation.domain.Curation;
+import org.cubco.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CurationRepository extends JpaRepository<Curation, Long> {
+    boolean existsByUserAndId(User user, Long curationId);
+}

--- a/cubco-domain/src/main/java/org/cubco/image/repository/CurationImageRepository.java
+++ b/cubco-domain/src/main/java/org/cubco/image/repository/CurationImageRepository.java
@@ -1,0 +1,13 @@
+package org.cubco.image.repository;
+
+import org.cubco.curation.domain.Curation;
+import org.cubco.image.domain.CurationImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface CurationImageRepository extends JpaRepository<CurationImage, Long> {
+    List<CurationImage>  findAllByCuration(Curation curation);
+}

--- a/cubco-domain/src/main/java/org/cubco/like/repository/LikeRepository.java
+++ b/cubco-domain/src/main/java/org/cubco/like/repository/LikeRepository.java
@@ -1,0 +1,14 @@
+package org.cubco.like.repository;
+
+import org.cubco.curation.domain.Curation;
+import org.cubco.like.domain.Like;
+import org.cubco.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LikeRepository extends JpaRepository<Like, Long> {
+    int countByCuration(Curation curation);
+    boolean existsLikeByUserAndCuration(User user, Curation curation);
+    Like findLikeByUserAndCuration(User user, Curation curation);
+}

--- a/cubco-domain/src/main/java/org/cubco/tag/repository/CurationTagRepository.java
+++ b/cubco-domain/src/main/java/org/cubco/tag/repository/CurationTagRepository.java
@@ -1,0 +1,13 @@
+package org.cubco.tag.repository;
+
+import org.cubco.curation.domain.Curation;
+import org.cubco.tag.domain.CurationTag;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface CurationTagRepository extends JpaRepository<CurationTag, Long> {
+    List<CurationTag> findAllByCuration(Curation curation);
+}

--- a/cubco-domain/src/main/java/org/cubco/user/domain/User.java
+++ b/cubco-domain/src/main/java/org/cubco/user/domain/User.java
@@ -56,7 +56,7 @@ public class User extends BaseTimeEntity {
     @Column(name = "status")
     private Status status;
 
-    public static User create(String name, String email, String phone, String city, SocialType socialType, String socialId) {
+    public static User create(String name, String email, String phone, String city, SocialType socialType, String socialId, Status status, RoleType role) {
         return User.builder()
                 .name(name)
                 .email(email)
@@ -64,8 +64,8 @@ public class User extends BaseTimeEntity {
                 .city(city)
                 .socialType(socialType)
                 .socialId(socialId)
-                .status(Status.ACTIVE)
-                .roleType(RoleType.MEMBER)
+                .status(status)
+                .roleType(role)
                 .build();
     }
 }

--- a/cubco-domain/src/main/java/org/cubco/user/repository/UserRepository.java
+++ b/cubco-domain/src/main/java/org/cubco/user/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package org.cubco.user.repository;
+
+import org.cubco.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+}

--- a/cubco-external/build.gradle
+++ b/cubco-external/build.gradle
@@ -1,4 +1,7 @@
 dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'software.amazon.awssdk:bom:2.21.31'
+    implementation 'software.amazon.awssdk:s3:2.21.31'
     implementation project(path: ':cubco-common')
 }
 

--- a/cubco-external/src/main/java/org/cubco/s3/AWSConfig.java
+++ b/cubco-external/src/main/java/org/cubco/s3/AWSConfig.java
@@ -1,0 +1,46 @@
+package org.cubco.s3;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.SystemPropertyCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+@RequiredArgsConstructor
+public class AWSConfig {
+    private static final String AWS_ACCESS_KEY_ID = "aws.accessKeyId";
+    private static final String AWS_SECRET_ACCESS_KEY = "aws.secretAccessKey";
+
+    @Value("${aws-property.access-key}")
+    private String accessKey;
+
+    @Value("${aws-property.secret-key}")
+    private String secretKey;
+
+    @Value("${aws-property.aws-region}")
+    private String region;
+
+    @Bean
+    public SystemPropertyCredentialsProvider systemPropertyCredentialsProvider() {
+        System.setProperty(AWS_ACCESS_KEY_ID, accessKey);
+        System.setProperty(AWS_SECRET_ACCESS_KEY, secretKey);
+        return SystemPropertyCredentialsProvider.create();
+    }
+
+    @Bean
+    public Region getRegion() {
+        return Region.of(region);
+    }
+
+    @Bean
+    public S3Client getS3Client() {
+        return S3Client.builder()
+                .region(getRegion())
+                .credentialsProvider(systemPropertyCredentialsProvider())
+                .build();
+    }
+
+}

--- a/cubco-external/src/main/java/org/cubco/s3/S3Service.java
+++ b/cubco-external/src/main/java/org/cubco/s3/S3Service.java
@@ -1,0 +1,119 @@
+package org.cubco.s3;
+
+import lombok.extern.slf4j.Slf4j;
+import org.cubco.exception.ErrorCode;
+import org.cubco.exception.InvalidValueException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+@Slf4j
+@Component
+public class S3Service {
+    private final String bucketName;
+    private final AWSConfig awsConfig;
+    private static final List<String> IMAGE_EXTENSIONS = Arrays.asList("image/jpeg", "image/png", "image/jpg", "image/webp", "image/heic", "image/heif");
+    private static final Long MAX_FILE_SIZE = 5 * 1024 * 1024L; // 최대 5MB
+
+    public S3Service(@Value("${aws-property.s3.bucketName}") String bucketName, AWSConfig awsConfig) {
+        this.bucketName = bucketName;
+        this.awsConfig = awsConfig;
+    }
+
+    public String uploadImage(String directoryPath, MultipartFile image, Long id) throws IOException {
+        final S3Client s3Client = awsConfig.getS3Client();
+        String imageName = directoryPath + id + generateImageFileName(image);  // 이미지 파일 이름 생성
+        // 파일 유효성 검사
+        checkInvalidUploadFile(image);
+        validateExtension(image);
+        validateFileSize(image);
+
+        PutObjectRequest request = PutObjectRequest.builder()
+                .bucket(bucketName)
+                .key(imageName)
+                .contentType(image.getContentType())
+                .contentDisposition("inline")
+                .build();
+        RequestBody requestBody = RequestBody.fromBytes(image.getBytes());
+        try {
+            s3Client.putObject(request, requestBody);
+        } catch (S3Exception e) {
+            log.error("Image Upload Error: {}", e.getMessage());
+            throw new IOException("파일 업로드에 실패했습니다.", e);
+        }
+        return s3Client.utilities().getUrl(builder ->
+                builder.bucket(bucketName).key(imageName)).toExternalForm();
+    }
+
+    public void deleteImage(String imageUrl) {
+        final S3Client s3Client = awsConfig.getS3Client();
+        String imageName = extractKeyFromUrl(imageUrl);
+        try {
+            s3Client.deleteObject(DeleteObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(imageName)
+                    .build());
+        } catch (S3Exception e) {
+            log.error("Image Delete Error: {}", e.getMessage());
+            throw new InvalidValueException(ErrorCode.FAIL_DELETE_IMAGE);
+        }
+    }
+
+    private String extractKeyFromUrl(String imageUrl) {
+        String host = "https://" + bucketName + ".s3." + awsConfig.getRegion().id() + ".amazonaws.com/";
+        if (imageUrl.startsWith(host)) {
+            return imageUrl.substring(host.length());
+        }
+        throw new InvalidValueException(ErrorCode.INVALID_IMAGE_URL);
+    }
+
+    // 이미지 파일 이름을 UUID 기반으로 생성
+    public String generateImageFileName(MultipartFile image) {
+        String extension = getExtension(Objects.requireNonNull(image.getContentType()));
+        return "/" + UUID.randomUUID() + extension;
+    }
+
+    // 확장자에 맞는 파일 포맷 가져오기
+    private String getExtension(String contentType) {
+        return switch (contentType) {
+            case "image/png" -> ".png";
+            case "image/webp" -> ".webp";
+            case "image/heic" -> ".heic";
+            case "image/heif" -> ".heif";
+            default -> ".jpg";
+        };
+    }
+
+    // 이미지 파일 확장자 유효성 검사
+    private void validateExtension(MultipartFile image) {
+        String contentType = image.getContentType();
+        if (!IMAGE_EXTENSIONS.contains(contentType)) {
+            throw new InvalidValueException(ErrorCode.INVALID_FILE_EXTENSION);
+        }
+    }
+
+    // 이미지 파일 크기 유효성 검사
+    private void validateFileSize(MultipartFile image) {
+        if (image.getSize() > MAX_FILE_SIZE) {
+            throw new InvalidValueException(ErrorCode.INVALID_FILE_SIZE);
+        }
+    }
+
+    // 파일이 비어있거나 크기가 0인 경우 유효하지 않음
+    private void checkInvalidUploadFile(MultipartFile image) {
+        if (image.isEmpty() || image.getSize() == 0) {
+            throw new InvalidValueException(ErrorCode.INVALID_FILE_EMPTY);
+        }
+    }
+}


### PR DESCRIPTION
## 🔥*Pull requests*

#️⃣️ **작업한 브랜치**
- feature/#14

📄  **작업한 내용**
###  큐레이션 관련 기능 구현
- 큐레이션 생성 API 구현
- 큐레이션 상세 조회 API 구현
- 큐레이션 좋아요 및 좋아요 취소 API 구현

### S3 이미지 업로드 기능 구현
- AWS S3 연동 설정
- 이미지 업로드 및 삭제 기능 구현
- 이미지 확장자 및 크기 유효성 검사 로직 구현

### 비동기 처리 기능 구현
- 이미지 업로드 및 태그 생성 비동기 처리

## 🚨 참고 사항
- 비동기 처리는 이후에 추가로 보완할 예정이고, 이미지 관련 로직도 PresignedUrl이나 CloudFront 도입해서 성능개선 예정입니다.
- 제목은 최소 5글자 이상, 내용은 최소 10글자 이상으로 작성해야 합니다.
- 큐레이션 이미지는 최소 1개, 최대 10개까지 업로드 가능합니다
- 큐레이션 태그는 최소 1개, 최대 5개까지 추가 가능합니다
- AWS S3 버킷에 이미지 업로드 시 최대 파일 크기는 5MB로 제한하였습니다
- 지원하는 이미지 포맷: JPEG, PNG, WEBP, HEIC, HEIF

## 💻 관련 이슈
- Resolved: #14 

## 💬 리뷰 요구사항 (선택)
